### PR TITLE
Separate MYSQL_USER from the root user

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -8,6 +8,7 @@ FROM centos:centos7
 #  * $MYSQL_USER - Database user name
 #  * $MYSQL_PASSWORD - User's password
 #  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD - MySQL root user password (optional)
 
 # Image metadata
 ENV MYSQL_VERSION           = "5.5" \

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -8,6 +8,7 @@ FROM rhel7
 #  * $MYSQL_USER - Database user name
 #  * $MYSQL_PASSWORD - User's password
 #  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD - MySQL root password (optional)
 
 # Image metadata
 ENV MYSQL_VERSION           = "5.5" \

--- a/5.5/mysql/bin/run-mysqld.sh
+++ b/5.5/mysql/bin/run-mysqld.sh
@@ -12,11 +12,14 @@ test -z "$MYSQL_USER" && usage
 test -z "$MYSQL_PASSWORD" && usage
 test -z "$MYSQL_DATABASE" && usage
 
+MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-$(cat /dev/urandom | tr -dc 'a-zA-Z0-9-_!@#$%^&*()_+{}|:<>?=' | fold -w 12 | head -n 1)}
+
 if [ ! -d '/var/lib/mysql/data' ]; then
 
 	echo 'Running mysql_install_db ...'
 	scl enable mysql55 "mysql_install_db --user=mysql --datadir=/var/lib/mysql/data"
 	echo 'Finished mysql_install_db'
+	chown -R mysql:mysql /var/lib/mysql
 
 	# These statements _must_ be on individual lines, and _must_ end with
 	# semicolons (no line breaks or comments are permitted).
@@ -24,17 +27,17 @@ if [ ! -d '/var/lib/mysql/data' ]; then
 	TEMP_FILE='/tmp/mysql-first-time.sql'
 	cat > "$TEMP_FILE" <<-EOSQL
 		DELETE FROM mysql.user ;
-		CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}' ;
-		GRANT ALL ON *.* TO '${MYSQL_USER}'@'%' WITH GRANT OPTION ;
+		CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+		GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
 		DROP DATABASE IF EXISTS test ;
 		CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` ;
+		CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}' ;
+		GRANT ALL ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%' ;
 		FLUSH PRIVILEGES ;
 	EOSQL
 
 	set -- "$@" --init-file="$TEMP_FILE"
 fi
-
-chown -R mysql:mysql /var/lib/mysql
 
 # SCL in CentOS/RHEL 7 doesn't support --exec, we need to do it ourselves
 export X_SCLS="mysql55"


### PR DESCRIPTION
MySQL root user password can now be added optionally through the
MYSQL_ROOT_PASSWORD environment variable.

I know we talked about using 'admin', but it really seems to me that root is more common, e.g. in MySQL documentation.

I'm using the weird /dev/urandom magic because installing pwgen can be a real hassle (especially on rhel).