### PR TITLE
Initialization sophistication

### DIFF
--- a/5.5/mysql/bin/run-mysqld.sh
+++ b/5.5/mysql/bin/run-mysqld.sh
@@ -12,10 +12,10 @@ test -z "$MYSQL_USER" && usage
 test -z "$MYSQL_PASSWORD" && usage
 test -z "$MYSQL_DATABASE" && usage
 
-if [ ! -d '/var/lib/mysql/data' ]; then
+if [ ! -d '/var/lib/mysql' ]; then
 
 	echo 'Running mysql_install_db ...'
-	scl enable mysql55 "mysql_install_db --user=mysql --datadir=/var/lib/mysql/data"
+	scl enable mysql55 "mysql_install_db --user=mysql --datadir=/var/lib/mysql"
 	echo 'Finished mysql_install_db'
 
 	# These statements _must_ be on individual lines, and _must_ end with

--- a/5.5/mysql/bin/run-mysqld.sh
+++ b/5.5/mysql/bin/run-mysqld.sh
@@ -1,43 +1,96 @@
 #!/bin/bash -e
 
+# Be paranoid and stricter than we should be.
+# https://dev.mysql.com/doc/refman/5.5/en/identifiers.html
+mysql_identifier_regex='^[a-zA-Z0-9_]+$'
+mysql_password_regex='^[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]+$'
+
 function usage {
 	echo "You must specify following environment variables:"
-	echo "  \$MYSQL_USER"
-	echo "  \$MYSQL_PASSWORD"
-	echo "  \$MYSQL_DATABASE"
+	echo "  \$MYSQL_USER (regex: '$mysql_identifier_regex')"
+	echo "  \$MYSQL_PASSWORD (regex: '$mysql_password_regex')"
+	echo "  \$MYSQL_DATABASE (regex: '$mysql_identifier_regex')"
+	echo "Optional:"
+	echo "  \$MYSQL_ROOT_PASSWORD (regex: '$mysql_password_regex')"
 	exit 1
 }
 
-test -z "$MYSQL_USER" && usage
-test -z "$MYSQL_PASSWORD" && usage
-test -z "$MYSQL_DATABASE" && usage
+function valid_mysql_identifier {
+	local var="$1" ; shift
+	[[ "${var}" =~ $mysql_identifier_regex ]]
+}
 
-if [ ! -d '/var/lib/mysql' ]; then
+function valid_mysql_password {
+	local var="$1" ; shift
+	[[ "${var}" =~ $mysql_password_regex ]]
+}
 
-	echo 'Running mysql_install_db ...'
-	scl enable mysql55 "mysql_install_db --user=mysql --datadir=/var/lib/mysql"
-	echo 'Finished mysql_install_db'
+valid_mysql_identifier "$MYSQL_USER"     || usage
+valid_mysql_password   "$MYSQL_PASSWORD" || usage
+valid_mysql_identifier "$MYSQL_DATABASE" || usage
 
-	# These statements _must_ be on individual lines, and _must_ end with
-	# semicolons (no line breaks or comments are permitted).
-	# TODO proper SQL escaping on ALL the things D:
-	TEMP_FILE='/tmp/mysql-first-time.sql'
-	cat > "$TEMP_FILE" <<-EOSQL
-		DELETE FROM mysql.user ;
-		CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}' ;
-		GRANT ALL ON *.* TO '${MYSQL_USER}'@'%' WITH GRANT OPTION ;
-		DROP DATABASE IF EXISTS test ;
-		CREATE DATABASE IF NOT EXISTS \`${MYSQL_DATABASE}\` ;
+# Make sure env variables don't propagate to mysqld process.
+mysql_user="$MYSQL_USER" ; unset MYSQL_USER
+mysql_pass="$MYSQL_PASSWORD" ; unset MYSQL_PASSWORD
+mysql_db="$MYSQL_DATABASE" ; unset MYSQL_DATABASE
+
+# Root password.
+if [ "$MYSQL_ROOT_PASSWORD" ]; then
+	valid_mysql_password "$MYSQL_ROOT_PASSWORD" || usage
+	root_pass="$MYSQL_ROOT_PASSWORD"
+fi
+unset MYSQL_ROOT_PASSWORD
+
+# SCL in CentOS/RHEL 7 doesn't support --exec, we need to do it ourselves
+# The '|| exit 1' is here so -e doesn't propagate into scl_source.
+source scl_source enable mysql55 || exit 1
+
+# Poll until MySQL responds to our ping.
+function wait_for_mysql {
+	pid=$1 ; shift
+
+	while [ true ]; do
+		if [ -d "/proc/$pid" ]; then
+			mysqladmin --socket=/tmp/mysql.sock ping &>/dev/null && return 0
+		else
+			return 1
+		fi
+		echo "Waiting for MySQL to start"
+		sleep 1
+	done
+}
+
+if [ ! -d '/var/lib/mysql/mysql' ]; then
+
+	echo 'Running mysql_install_db'
+	mysql_install_db --user=mysql --datadir=/var/lib/mysql
+	# TODO: Not needed with --user=mysql. However, we should
+	#       strive to make this script runnable without root privileges
+	#chown -R mysql:mysql /var/lib/mysql
+
+	# Now start mysqld and add appropriate users.
+	echo 'Starting mysqld to create users'
+	/opt/rh/mysql55/root/usr/libexec/mysqld \
+		--defaults-file=/opt/openshift/etc/my.cnf \
+		--skip-networking --socket=/tmp/mysql.sock &
+	mysql_pid=$!
+	wait_for_mysql $mysql_pid
+
+	mysqladmin --socket=/tmp/mysql.sock -f drop test
+	mysqladmin --socket=/tmp/mysql.sock create "${mysql_db}"
+	mysql --socket=/tmp/mysql.sock <<-EOSQL
+		CREATE USER '${mysql_user}'@'%' IDENTIFIED BY '${mysql_pass}';
+		GRANT ALL ON \`${mysql_db}\`.* TO '${mysql_user}'@'%' ;
 		FLUSH PRIVILEGES ;
 	EOSQL
 
-	set -- "$@" --init-file="$TEMP_FILE"
+	if [ -v root_pass ]; then
+		mysqladmin --socket=/tmp/mysql.sock password "${root_pass}" flush-privileges shutdown
+	else
+		mysqladmin --socket=/tmp/mysql.sock shutdown
+	fi
 fi
 
-chown -R mysql:mysql /var/lib/mysql
-
-# SCL in CentOS/RHEL 7 doesn't support --exec, we need to do it ourselves
-export X_SCLS="mysql55"
-source /opt/rh/mysql55/enable
-
-exec /opt/rh/mysql55/root/usr/libexec/mysqld --defaults-file=/opt/openshift/etc/my.cnf "$@" 2>&1
+exec /opt/rh/mysql55/root/usr/libexec/mysqld \
+	--defaults-file=/opt/openshift/etc/my.cnf \
+	"$@" 2>&1

--- a/5.5/mysql/etc/my.cnf
+++ b/5.5/mysql/etc/my.cnf
@@ -7,7 +7,8 @@ plugin-dir=/opt/rh/mysql55/root/usr/lib64/mysql/plugin
 
 general_log=ON
 
-socket=/var/lib/mysql/mysql.sock
+# Disable unix socket
+socket=
 
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links=0

--- a/5.5/mysql/etc/my.cnf
+++ b/5.5/mysql/etc/my.cnf
@@ -1,7 +1,7 @@
 [mysqld]
 user=mysql
 
-datadir=/var/lib/mysql/data
+datadir=/var/lib/mysql
 basedir=/opt/rh/mysql55/root/usr
 plugin-dir=/opt/rh/mysql55/root/usr/lib64/mysql/plugin
 

--- a/5.5/test/run
+++ b/5.5/test/run
@@ -29,7 +29,7 @@ cleanup() {
 test_connection() {
 	echo "  Testing MySQL connection to $(get_container_ip)..."
 	local max_attempts=10
-	local sleep_time=1
+	local sleep_time=2
 	local attempt=1
 	while [ $attempt -le $max_attempts ]; do
 		echo "    Trying to connect..."
@@ -60,6 +60,7 @@ test_mysql() {
 }
 
 
+# TODO: Test with root password
 CONTAINER_ID=$(docker run -d -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db $IMAGE_NAME)
 trap "cleanup '$CONTAINER_ID'" EXIT
 


### PR DESCRIPTION
We now start mysqld after initialization, without network. We initialize
it, using CLI wherever possible instead of SQL files. After
initialization is done, we properly shutdown the server and then start
it again properly, using exec.
    
We also use 'source scl_source enable mysql55' instead of X_SCLS. It is
not supported as well, but should be a bit safer.

So far I've only tested this for CentOS. I have a problem with my RHEL setup atm and I want to enhance the test/run script before testing that.