### PR TITLE
Remove ugly {user,group}add

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -18,13 +18,14 @@ ENV IMAGE_EXPOSE_SERVICES   3306:mysql
 MAINTAINER  Martin Nagy <mnagy@redhat.com>
 EXPOSE 3306
 
-RUN groupadd -g 27 -o -r mysql && \
-    useradd -M -N -g mysql -o -r -d /var/lib/mysql -s /sbin/nologin -c "MySQL Server" -u 27 mysql
-
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
 RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum -y --setopt=tsflags=nodocs install https://www.softwarecollections.org/en/scls/rhscl/mysql55/epel-7-x86_64/download/rhscl-mysql55-epel-7-x86_64.noarch.rpm && \
     yum -y --setopt=tsflags=nodocs install hostname mysql55 && \
-    yum clean all
+    yum clean all && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 COPY run-mysqld.sh /usr/local/bin/
 COPY mysql /opt/openshift/

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -18,14 +18,15 @@ ENV IMAGE_EXPOSE_SERVICES   3306:mysql
 MAINTAINER  Martin Nagy <mnagy@redhat.com>
 EXPOSE 3306
 
-RUN groupadd -g 27 -o -r mysql && \
-    useradd -M -N -g mysql -o -r -d /var/lib/mysql -s /sbin/nologin -c "MySQL Server" -u 27 mysql
-
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
 RUN yum install -y yum-utils hostname && \
     yum-config-manager --enable rhel-server-rhscl-7-rpms && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum install -y --setopt=tsflags=nodocs mysql55 && \
-    yum clean all
+    yum clean all && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 COPY run-mysqld.sh /usr/local/bin/
 COPY mysql /opt/openshift/


### PR DESCRIPTION
The Fedora/CentOS/RHEL mariadb/mysql rpms add mysql user and group in
the same manner we do (it was copied from it). It is not supposed to be
changed in future releases. Adding the user and group ourselves is very
ugly and the plethora of flags is confusing. Instead of that, we'll just
test that the UID is 27 in the Dockerfile. Even if UID in upstream image
would change, we'll get a build failure.

I realize this might be controversial (looking at you, @mfojtik), but I
really can't see any downside to be honest and people from the SCL team
that might end up maintaining this also were of the opinion that this
would be a better option.