### PR TITLE
Don't run the container as root and other improvements

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -8,6 +8,7 @@ FROM centos:centos7
 #  * $MYSQL_USER - Database user name
 #  * $MYSQL_PASSWORD - User's password
 #  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 # Image metadata
 ENV MYSQL_VERSION           5.5
@@ -25,11 +26,14 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum -y --setopt=tsflags=nodocs install https://www.softwarecollections.org/en/scls/rhscl/mysql55/epel-7-x86_64/download/rhscl-mysql55-epel-7-x86_64.noarch.rpm && \
     yum -y --setopt=tsflags=nodocs install hostname mysql55 && \
     yum clean all && \
+    mkdir -p /var/lib/mysql && chown mysql.mysql /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 COPY run-mysqld.sh /usr/local/bin/
 COPY mysql /opt/openshift/
 
 VOLUME ["/var/lib/mysql"]
+
+USER mysql
 
 ENTRYPOINT ["run-mysqld.sh"]

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -8,6 +8,7 @@ FROM rhel7
 #  * $MYSQL_USER - Database user name
 #  * $MYSQL_PASSWORD - User's password
 #  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
 # Image metadata
 ENV MYSQL_VERSION           5.5
@@ -26,11 +27,14 @@ RUN yum install -y yum-utils hostname && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum install -y --setopt=tsflags=nodocs mysql55 && \
     yum clean all && \
+    mkdir -p /var/lib/mysql && chown mysql.mysql /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 COPY run-mysqld.sh /usr/local/bin/
 COPY mysql /opt/openshift/
 
 VOLUME ["/var/lib/mysql"]
+
+USER mysql
 
 ENTRYPOINT ["run-mysqld.sh"]

--- a/5.5/test/run
+++ b/5.5/test/run
@@ -19,13 +19,18 @@ cleanup() {
 
 		echo "Stopping and removing container $CONTAINER..."
 		docker stop $CONTAINER
+		exit_status=$(docker inspect -f '{{.State.ExitCode}}' $CONTAINER)
+		if [ "$exit_status" != "0" ]; then
+			echo "Dumping logs for $CONTAINER"
+			docker logs $CONTAINER
+		fi
 		docker rm $CONTAINER
 		rm $cidfile
 		echo "Done."
 	done
 	rmdir $CIDFILE_DIR
 }
-trap cleanup EXIT
+trap cleanup EXIT SIGINT
 
 get_cid () {
 	local id="$1" ; shift || return 1
@@ -38,7 +43,7 @@ get_container_ip() {
 }
 
 mysql_cmd() {
-	docker run --rm --entrypoint=scl $IMAGE_NAME enable mysql55 -- mysql --host $CONTAINER_IP -u$USER -p$PASS "$@" db
+	docker run --rm --entrypoint=scl $IMAGE_NAME enable mysql55 -- mysql --host $CONTAINER_IP -u$USER -p"$PASS" "$@" db
 }
 
 test_connection() {


### PR DESCRIPTION
This PR syncs MySQL image with some changes we introduced for PostgreSQL,
most notably it now allows the image to run under non-privileged user.
We now assume that the provided volume is writable. We also include a
writable directory in the image in case no other is provided.

Also some minor fixes and improvements to the test suite.