### PR TITLE
Support random uid at runtime

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -33,9 +33,13 @@ COPY run-*.sh /usr/local/bin/
 
 COPY contrib /var/lib/mysql/
 
+RUN chmod o+w -R /var/lib/mysql
+
 VOLUME ["/var/lib/mysql/data"]
 
 USER mysql
+
+ENV HOME /var/lib/mysql
 
 ENTRYPOINT ["run-mysqld.sh"]
 CMD ["mysqld"]

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -35,9 +35,13 @@ COPY run-*.sh /usr/local/bin/
 
 COPY contrib /var/lib/mysql/
 
+RUN chmod o+w -R /var/lib/mysql
+
 VOLUME ["/var/lib/mysql/data"]
 
 USER mysql
+
+ENV HOME /var/lib/mysql
 
 ENTRYPOINT ["run-mysqld.sh"]
 CMD ["mysqld"]

--- a/5.5/test/run
+++ b/5.5/test/run
@@ -82,9 +82,10 @@ function test_mysql() {
 
 function create_container() {
   local name=$1 ; shift
+  local cargs=${CONTAINER_ARGS:-}
   cidfile="$CIDFILE_DIR/$name"
   # create container with a cidfile in a directory for cleanup
-  docker run --cidfile $cidfile -d "$@" $IMAGE_NAME
+  docker run $cargs --cidfile $cidfile -d "$@" $IMAGE_NAME
   echo "Created container $(cat $cidfile)"
 }
 
@@ -191,3 +192,6 @@ run_container_creation_tests
 
 USER=user PASS=pass run_tests no_root
 USER=user1 PASS=pass1 ROOT_PASS=r00t run_tests root
+# Test with arbitrary uid for the container
+CONTAINER_ARGS="-u 12345" USER=user PASS=pass run_tests no_root_altuid
+CONTAINER_ARGS="-u 12345" USER=user1 PASS=pass1 ROOT_PASS=r00t run_tests root_altuid


### PR DESCRIPTION
Allows running this container with any uid by making the home/data directory
world-writeable and setting the HOME directory explicitly in the startup script. 
Example:
```
docker run -p 3306:3306 -u 12345 -e MYSQL_USER=user -e MYSQL_PASSWORD=pass \
   -e MYSQL_DATABASE=db1 -e HOME=/var/lib/mysql openshift/mysql-55-centos7
```
