### PR TITLE
Disable general_log

### DIFF
--- a/5.5/contrib/my.cnf.template
+++ b/5.5/contrib/my.cnf.template
@@ -5,8 +5,6 @@ datadir = ${MYSQL_DATADIR}
 basedir = /opt/rh/mysql55/root/usr
 plugin-dir = /opt/rh/mysql55/root/usr/lib64/mysql/plugin
 
-general_log = ON
-
 # Disable unix socket
 socket =
 


### PR DESCRIPTION
With general log ON, we've been logging all queries to a files, which
can have security and performance impact. Fixes bug 1216002.