### PR TITLE
Make mysql command work out of the box

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -13,7 +13,8 @@ FROM centos:centos7
 MAINTAINER  Martin Nagy <mnagy@redhat.com>
 
 ENV MYSQL_VERSION=5.5 \
-    HOME=/var/lib/mysql
+    HOME=/var/lib/mysql \
+    BASH_ENV=/var/lib/mysql/.bashrc
 
 LABEL k8s.io/description="MySQL is a multi-user, multi-threaded SQL database server" \
       k8s.io/display-name="MySQL 5.5" \

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -13,7 +13,8 @@ FROM rhel7
 MAINTAINER  Martin Nagy <mnagy@redhat.com>
 
 ENV MYSQL_VERSION=5.5 \
-    HOME=/var/lib/mysql
+    HOME=/var/lib/mysql \
+    BASH_ENV=/var/lib/mysql/.bashrc
 
 LABEL k8s.io/description="MySQL is a multi-user, multi-threaded SQL database server" \
       k8s.io/display-name="MySQL 5.5" \

--- a/5.5/contrib/my.cnf.template
+++ b/5.5/contrib/my.cnf.template
@@ -5,9 +5,6 @@ datadir = ${MYSQL_DATADIR}
 basedir = /opt/rh/mysql55/root/usr
 plugin-dir = /opt/rh/mysql55/root/usr/lib64/mysql/plugin
 
-# Disable unix socket
-socket =
-
 # Disabling symbolic-links is recommended to prevent assorted security risks
 symbolic-links = 0
 

--- a/5.5/run-mysqld-master.sh
+++ b/5.5/run-mysqld-master.sh
@@ -2,7 +2,6 @@
 #
 # This is an entrypoint that runs the MySQL server in the 'master' mode.
 #
-source ${HOME}/.bashrc
 source ${HOME}/common.sh
 
 set -eu

--- a/5.5/run-mysqld-slave.sh
+++ b/5.5/run-mysqld-slave.sh
@@ -2,7 +2,6 @@
 #
 # This is an entrypoint that runs the MySQL server in the 'slave' mode.
 #
-source ${HOME}/.bashrc
 source ${HOME}/common.sh
 
 set -eu

--- a/5.5/run-mysqld.sh
+++ b/5.5/run-mysqld.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-source $HOME/.bashrc
 source $HOME/common.sh
 set -eu
 

--- a/5.5/test/run
+++ b/5.5/test/run
@@ -101,6 +101,11 @@ function assert_login_access() {
   fi
 }
 
+function assert_local_access() {
+  local id="$1" ; shift
+  docker exec $(get_cid "$id") bash -c mysql <<< "SELECT 1;"
+}
+
 # Make sure the invocation of docker run fails.
 function assert_container_creation_fails() {
 
@@ -178,6 +183,7 @@ function run_tests() {
     assert_login_access root "foo" false
     assert_login_access root "" false
   fi
+  assert_local_access $name
   echo "  Success!"
   test_mysql $name
 }


### PR DESCRIPTION
Enable mysql unix socket and set BASH_ENV so that docker
`exec -ti CONTAINER_ID bash -c mysql` works correctly.

Fixes #45

@mfojtik @hhorak