### PR TITLE
Some fixes to MySQL replication example

### DIFF
--- a/5.5/contrib/common.sh
+++ b/5.5/contrib/common.sh
@@ -70,19 +70,21 @@ function wait_for_mysql() {
   done
 }
 
+function start_local_mysql() {
+  # Now start mysqld and add appropriate users.
+  echo 'Starting local mysqld server ...'
+  /opt/rh/mysql55/root/usr/libexec/mysqld \
+    --defaults-file=$MYSQL_DEFAULTS_FILE \
+    --skip-networking --socket=/tmp/mysql.sock &
+  mysql_pid=$!
+  wait_for_mysql $mysql_pid
+}
+
 # Initialize the MySQL database (create user accounts and the initial database)
 function initialize_database() {
   echo 'Running mysql_install_db ...'
   mysql_install_db --datadir=$MYSQL_DATADIR
-
-  # Now start mysqld and add appropriate users.
-  echo 'Starting mysqld to create users ...'
-  /opt/rh/mysql55/root/usr/libexec/mysqld \
-    --defaults-file=$MYSQL_DEFAULTS_FILE \
-    --skip-networking --socket=/tmp/mysql.sock &
-
-  mysql_pid=$!
-  wait_for_mysql $mysql_pid
+  start_local_mysql
 
   [ -v MYSQL_DISABLE_CREATE_DB ] && return
 

--- a/5.5/examples/replica/README.md
+++ b/5.5/examples/replica/README.md
@@ -19,8 +19,15 @@ See: https://dev.mysql.com/doc/refman/5.5/en/replication.html
 
 ## How does this example work?
 
-The provided JSON file (`mysql_replica.json`) contains a `Config` resource that
+The provided JSON file (`mysql_replica.json`) contains a `Template` resource that
 groups the Kubernetes and OpenShift resources which are meant to be created.
+This template will start with one MySQL master server and one slave server.
+
+## Persistent storage
+
+In order to provide the persistent storage for the MySQL master server, the administrator
+of OpenShift needs to create a PersistentVolume that you can claim. This example requires a PersistentVolume of size 512m be available.
+To learn more about how to create PersistentVolume, refer to [OpenShift documentation](https://docs.openshift.org/latest/admin_guide/persistent_storage_nfs.html)
 
 ### Service 'mysql-master'
 

--- a/5.5/examples/replica/mysql_replica.json
+++ b/5.5/examples/replica/mysql_replica.json
@@ -47,6 +47,23 @@
   ],
   "objects": [
     {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql-master"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "512Mi"
+          }
+        }
+      }
+    },
+    {
       "kind": "Service",
       "apiVersion": "v1",
       "metadata": {
@@ -133,6 +150,14 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "mysql-master-data",
+                "persistentVolumeClaim": {
+                  "claimName": "mysql-master"
+                }
+              }
+            ],
             "containers": [
               {
                 "name": "server",
@@ -170,6 +195,12 @@
                   {
                     "name": "MYSQL_ROOT_PASSWORD",
                     "value": "${MYSQL_ROOT_PASSWORD}"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "mysql-master-data",
+                    "mountPath": "/var/lib/mysql/data"
                   }
                 ],
                 "resources": {},

--- a/5.5/run-mysqld-master.sh
+++ b/5.5/run-mysqld-master.sh
@@ -20,8 +20,27 @@ echo "The 'master' server-id is ${MYSQL_SERVER_ID}"
 envsubst < $HOME/my.cnf.template > $HOME/my-common.cnf
 envsubst < $HOME/my-master.cnf.template > $MYSQL_DEFAULTS_FILE
 
-# Initialize MySQL database
-initialize_database
+# Initialize MySQL database if this is the first time this containr runs and there
+# are no existing data. In other case just start the local mysql to allow editing
+# configuration
+if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
+  initialize_database
+else
+  start_local_mysql
+fi
+
+# Set the password for MySQL user and root everytime this container is started.
+# This allows to change the password by editing the deployment configuration.
+mysql $mysql_flags <<EOSQL
+  SET PASSWORD FOR '${MYSQL_USER}'@'%' = PASSWORD('${MYSQL_PASSWORD}');
+EOSQL
+
+# The MYSQL_ROOT_PASSWORD is optional
+if [ -v MYSQL_ROOT_PASSWORD ]; then
+mysql $mysql_flags <<EOSQL
+    SET PASSWORD FOR 'root'@'%' = PASSWORD('${MYSQL_ROOT_PASSWORD}');
+EOSQL
+fi
 
 # Setup the 'master' replication on the MySQL server
 mysql $mysql_flags <<EOSQL

--- a/5.5/run-mysqld.sh
+++ b/5.5/run-mysqld.sh
@@ -22,8 +22,24 @@ if [ "$1" == "mysqld" ]; then
 
   if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
     initialize_database
-    mysqladmin $admin_flags flush-privileges shutdown
+  else
+    start_local_mysql
   fi
+
+# Set the password for MySQL user and root everytime this container is started.
+# This allows to change the password by editing the deployment configuration.
+mysql $mysql_flags <<EOSQL
+  SET PASSWORD FOR '${MYSQL_USER}'@'%' = PASSWORD('${MYSQL_PASSWORD}');
+EOSQL
+
+# The MYSQL_ROOT_PASSWORD is optional
+if [ -v MYSQL_ROOT_PASSWORD ]; then
+mysql $mysql_flags <<EOSQL
+    SET PASSWORD FOR 'root'@'%' = PASSWORD('${MYSQL_ROOT_PASSWORD}');
+EOSQL
+fi
+
+  mysqladmin $admin_flags flush-privileges shutdown
 
   shift
   unset_env_vars

--- a/5.5/test/run
+++ b/5.5/test/run
@@ -89,6 +89,39 @@ function create_container() {
   echo "Created container $(cat $cidfile)"
 }
 
+function run_replication_test() {
+  local cluster_args="-e MYSQL_MASTER_USER=master -e MYSQL_MASTER_PASSWORD=master"
+  local max_attempts=30
+
+  # Run the MySQL master
+  docker run $cluster_args -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=db \
+    -d --cidfile ${CIDFILE_DIR}/master.cid $IMAGE_NAME mysqld-master
+  master_ip=$(get_container_ip master.cid)
+
+  # Run the MySQL slave
+  docker run $cluster_args -e MYSQL_MASTER_IP=${master_ip} \
+    -d --cidfile ${CIDFILE_DIR}/slave.cid $IMAGE_NAME mysqld-slave
+  slave_ip=$(get_container_ip slave.cid)
+
+  # Now wait till the MASTER will see the SLAVE
+  for i in $(seq $max_attempts); do
+    set +e
+    result=$(CONTAINER_IP=${master_ip} USER=root PASS=root \
+      mysql_cmd -e "SHOW SLAVE HOSTS;" | grep ${slave_ip})
+    set -e
+    if [[ ! -z "${result}" ]]; then
+      echo "${slave_ip} successfully registered as SLAVE for ${master_ip}"
+      break
+    fi
+    if [[ "${i}" == "${max_attempts}" ]]; then
+      echo "The ${slave_ip} failed to register in MASTER"
+      return 1
+    fi
+    sleep 1
+  done
+}
+
 function assert_login_access() {
   local USER=$1 ; shift
   local PASS=$1 ; shift
@@ -228,9 +261,11 @@ function run_tests() {
   test_mysql $name
 }
 
+
 # Tests.
 
 run_container_creation_tests
+
 # FIXME: Disabled because the configuration files are not processed when running
 #        commands like 'cat'. To have the my.cnf processed you have to run one of the
 #        valid entrypoints.
@@ -242,3 +277,6 @@ USER=user1 PASS=pass1 ROOT_PASS=r00t run_tests root
 # Test with arbitrary uid for the container
 CONTAINER_ARGS="-u 12345" USER=user PASS=pass run_tests no_root_altuid
 CONTAINER_ARGS="-u 12345" USER=user1 PASS=pass1 ROOT_PASS=r00t run_tests root_altuid
+
+# Replication tests
+run_replication_test

--- a/5.5/test/run
+++ b/5.5/test/run
@@ -89,6 +89,28 @@ function create_container() {
   echo "Created container $(cat $cidfile)"
 }
 
+function run_change_password_test() {
+  local tmpdir=$(mktemp -d)
+  mkdir "${tmpdir}/data" && chmod -R a+rwx "${tmpdir}"
+
+  # Create MySQL container with persistent volume and set the initial password
+  create_container "testpass1" -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
+    -e MYSQL_DATABASE=db -v ${tmpdir}:/var/lib/mysql/data:Z
+  CONTAINER_IP=$(get_container_ip testpass1) USER=user PASS=foo test_connection "testpass1"
+  docker stop $(get_cid testpass1)
+
+  # Create second container with changed password
+  create_container "testpass2" -e MYSQL_USER=user -e MYSQL_PASSWORD=bar \
+    -e MYSQL_DATABASE=db -v ${tmpdir}:/var/lib/mysql/data:Z
+  CONTAINER_IP=$(get_container_ip testpass2) USER=user PASS=bar test_connection "testpass2"
+
+  # The old password should not work anymore
+  set +e
+  CONTAINER_IP=$(get_container_ip testpass2) USER=user PASS=foo \
+    mysql_cmd -e "SELECT 1;" && return 1
+  set -e
+}
+
 function run_replication_test() {
   local cluster_args="-e MYSQL_MASTER_USER=master -e MYSQL_MASTER_PASSWORD=master"
   local max_attempts=30
@@ -261,7 +283,6 @@ function run_tests() {
   test_mysql $name
 }
 
-
 # Tests.
 
 run_container_creation_tests
@@ -277,6 +298,9 @@ USER=user1 PASS=pass1 ROOT_PASS=r00t run_tests root
 # Test with arbitrary uid for the container
 CONTAINER_ARGS="-u 12345" USER=user PASS=pass run_tests no_root_altuid
 CONTAINER_ARGS="-u 12345" USER=user1 PASS=pass1 ROOT_PASS=r00t run_tests root_altuid
+
+# Test the password change
+run_change_password_test
 
 # Replication tests
 run_replication_test


### PR DESCRIPTION
This PR will add `PersistentVolume` support to the MySQL replication example for the MySQL master server. 
This also allows users to change the password for the MySQL master by using `oc edit dc/mysql-master`.