### PR TITLE
Mysql 5.6 with GTID based replication

### DIFF
--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -1,0 +1,51 @@
+FROM centos:centos7
+
+# MySQL image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MySQL
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+MAINTAINER  Martin Nagy <mnagy@redhat.com>
+
+ENV MYSQL_VERSION=5.6 \
+    HOME=/var/lib/mysql
+
+LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database server" \
+      io.k8s.display-name="MySQL 5.6" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mysql56,rh-mysql56"
+
+EXPOSE 3306
+
+COPY run-*.sh /usr/local/bin/
+COPY contrib /var/lib/mysql/
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
+    yum -y --setopt=tsflags=nodocs install https://www.softwarecollections.org/en/scls/rhscl/rh-mysql56/epel-7-x86_64/download/rhscl-rh-mysql56-epel-7-x86_64.noarch.rpm && \
+    yum -y --setopt=tsflags=nodocs install gettext hostname bind-utils rh-mysql56 && \
+    yum clean all && \
+    mkdir -p /var/lib/mysql/data && chown mysql.mysql /var/lib/mysql/data && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)" && \
+    chmod o+w -R /var/lib/mysql
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=/var/lib/mysql/scl_enable \
+    ENV=/var/lib/mysql/scl_enable \
+    PROMPT_COMMAND=". /var/lib/mysql/scl_enable"
+
+VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["run-mysqld.sh"]
+CMD ["mysqld"]

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -1,0 +1,64 @@
+FROM rhel7
+
+# MySQL image for OpenShift.
+#
+# Volumes:
+#  * /var/lib/mysql/data - Datastore for MySQL
+# Environment:
+#  * $MYSQL_USER - Database user name
+#  * $MYSQL_PASSWORD - User's password
+#  * $MYSQL_DATABASE - Name of the database to create
+#  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
+
+MAINTAINER  Martin Nagy <mnagy@redhat.com>
+
+ENV MYSQL_VERSION=5.6 \
+    HOME=/var/lib/mysql
+
+LABEL k8s.io/description="MySQL is a multi-user, multi-threaded SQL database server" \
+      k8s.io/display-name="MySQL 5.6" \
+      openshift.io/expose-services="3306:mysql" \
+      openshift.io/tags="database,mysql,mysql56,rh-mysql56"
+
+LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database server" \
+      io.k8s.display-name="MySQL 5.6" \
+      io.openshift.expose-services="3306:mysql" \
+      io.openshift.tags="database,mysql,mysql56,rh-mysql56"
+
+# Labels consumed by Red Hat build service
+LABEL Component="rh-mysql56" \
+      Name="openshift3/mysql-56-rhel7" \
+      Version="5.6" \
+      Release="1"
+
+EXPOSE 3306
+
+COPY run-*.sh /usr/local/bin/
+COPY contrib /var/lib/mysql/
+
+# This image must forever use UID 27 for mysql user so our volumes are
+# safe in the future. This should *never* change, the last test is there
+# to make sure of that.
+RUN yum install -y yum-utils gettext hostname && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum-config-manager --enable rhel-7-server-optional-rpms && \
+    yum install -y --setopt=tsflags=nodocs bind-utils rh-mysql56 && \
+    yum clean all && \
+    mkdir -p /var/lib/mysql/data && chown mysql.mysql /var/lib/mysql/data && \
+    test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)" && \
+    chmod o+w -R /var/lib/mysql
+
+# When bash is started non-interactively, to run a shell script, for example it
+# looks for this variable and source the content of this file. This will enable
+# the SCL for all scripts without need to do 'scl enable'.
+ENV BASH_ENV=/var/lib/mysql/scl_enable \
+    ENV=/var/lib/mysql/scl_enable \
+    PROMPT_COMMAND=". /var/lib/mysql/scl_enable"
+
+
+VOLUME ["/var/lib/mysql/data"]
+
+USER 27
+
+ENTRYPOINT ["run-mysqld.sh"]
+CMD ["mysqld"]

--- a/5.6/contrib/common.sh
+++ b/5.6/contrib/common.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+
+# Data directory where MySQL database files live. The data subdirectory is here
+# because .bashrc and my.cnf both live in /var/lib/mysql/ and we don't want a
+# volume to override it.
+export MYSQL_DATADIR=/var/lib/mysql/data
+
+# Configuration settings.
+export MYSQL_DEFAULTS_FILE=$HOME/my.cnf
+export MYSQL_LOWER_CASE_TABLE_NAMES=${MYSQL_LOWER_CASE_TABLE_NAMES:-0}
+export MYSQL_MAX_CONNECTIONS=${MYSQL_MAX_CONNECTIONS:-151}
+export MYSQL_FT_MIN_WORD_LEN=${MYSQL_FT_MIN_WORD_LEN:-4}
+export MYSQL_FT_MAX_WORD_LEN=${MYSQL_FT_MAX_WORD_LEN:-20}
+export MYSQL_AIO=${MYSQL_AIO:-1}
+
+# Be paranoid and stricter than we should be.
+# https://dev.mysql.com/doc/refman/5.6/en/identifiers.html
+mysql_identifier_regex='^[a-zA-Z0-9_]+$'
+mysql_password_regex='^[a-zA-Z0-9_~!@#$%^&*()-=<>,.?;:|]+$'
+
+function usage() {
+  [ $# == 2 ] && echo "error: $1"
+  echo "You must specify following environment variables:"
+  echo "  MYSQL_USER (regex: '$mysql_identifier_regex')"
+  echo "  MYSQL_PASSWORD (regex: '$mysql_password_regex')"
+  echo "  MYSQL_DATABASE (regex: '$mysql_identifier_regex')"
+  echo "Optional:"
+  echo "  MYSQL_ROOT_PASSWORD (regex: '$mysql_password_regex')"
+  echo "Settings:"
+  echo "  MYSQL_LOWER_CASE_TABLE_NAMES (default: 0)"
+  echo "  MYSQL_MAX_CONNECTIONS (default: 151)"
+  echo "  MYSQL_FT_MIN_WORD_LEN (default: 4)"
+  echo "  MYSQL_FT_MAX_WORD_LEN (default: 20)"
+  echo "  MYSQL_AIO (default: 1)"
+  exit 1
+}
+
+function validate_variables() {
+  if ! [[ -v MYSQL_USER && -v MYSQL_PASSWORD && -v MYSQL_DATABASE ]]; then
+    usage
+  fi
+
+  [[ "$MYSQL_USER"     =~ $mysql_identifier_regex ]] || usage "Invalid MySQL username"
+  [ ${#MYSQL_USER} -le 16 ] || usage "MySQL username too long (maximum 16 characters)"
+  [[ "$MYSQL_PASSWORD" =~ $mysql_password_regex   ]] || usage "Invalid password"
+  [[ "$MYSQL_DATABASE" =~ $mysql_identifier_regex ]] || usage "Invalid database name"
+  [ ${#MYSQL_DATABASE} -le 64 ] || usage "Database name too long (maximum 64 characters)"
+  if [ -v MYSQL_ROOT_PASSWORD ]; then
+    [[ "$MYSQL_ROOT_PASSWORD" =~ $mysql_password_regex ]] || usage "Invalid root password"
+  fi
+}
+
+# Make sure env variables don't propagate to mysqld process.
+function unset_env_vars() {
+  unset MYSQL_USER MYSQL_PASSWORD MYSQL_DATABASE MYSQL_ROOT_PASSWORD
+}
+
+# Poll until MySQL responds to our ping.
+function wait_for_mysql() {
+  pid=$1 ; shift
+
+  while [ true ]; do
+    if [ -d "/proc/$pid" ]; then
+      mysqladmin --socket=/tmp/mysql.sock ping &>/dev/null && return 0
+    else
+      return 1
+    fi
+    echo "Waiting for MySQL to start ..."
+    sleep 1
+  done
+}
+
+function start_local_mysql() {
+  # Now start mysqld and add appropriate users.
+  echo 'Starting local mysqld server ...'
+  /opt/rh/rh-mysql56/root/usr/libexec/mysqld \
+    --defaults-file=$MYSQL_DEFAULTS_FILE \
+    --skip-networking --socket=/tmp/mysql.sock &
+  mysql_pid=$!
+  wait_for_mysql $mysql_pid
+}
+
+# Initialize the MySQL database (create user accounts and the initial database)
+function initialize_database() {
+  echo 'Running mysql_install_db ...'
+  # Using --rpm since we need mysql_install_db behaves as in RPM
+  mysql_install_db --rpm --datadir=$MYSQL_DATADIR
+  start_local_mysql
+
+  [ -v MYSQL_DISABLE_CREATE_DB ] && return
+
+  mysqladmin $admin_flags create "${MYSQL_DATABASE}"
+
+mysql $mysql_flags <<EOSQL
+    CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
+    GRANT ALL ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%' ;
+    FLUSH PRIVILEGES ;
+EOSQL
+
+  if [ -v MYSQL_ROOT_PASSWORD ]; then
+mysql $mysql_flags <<EOSQL
+    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+EOSQL
+  fi
+}
+
+# The 'server_id' number for slave needs to be within 1-4294967295 range.
+# This function will take the 'hostname' if the container, hash it and turn it
+# into the number.
+# See: https://dev.mysql.com/doc/refman/5.6/en/replication-options.html#option_mysqld_server-id
+function server_id() {
+  checksum=$(sha256sum <<< $(hostname -i))
+  checksum=${checksum:0:14}
+  echo -n $((0x${checksum}%4294967295))
+}
+
+function wait_for_mysql_master() {
+  local master_addr=""
+  while [ true ]; do
+    master_addr=$(mysql_master_addr)
+    [ ! -z "${master_addr}" ] && break
+    echo "Waiting for MySQL master service ..."
+    sleep 1
+  done
+  echo "Got MySQL master service address: ${master_addr}"
+  while [ true ]; do
+    mysqladmin --host=${master_addr} --user="${MYSQL_MASTER_USER}" \
+      --password="${MYSQL_MASTER_PASSWORD}" ping &>/dev/null && return 0
+    echo "Waiting for MySQL master (${master_addr}) to accept connections ..."
+    sleep 1
+  done
+}
+
+# mysql_master_addr lookups the 'mysql-master' DNS and get list of the available
+# endpoints. Each endpoint is a MySQL container with the 'master' MySQL running.
+function mysql_master_addr() {
+  local service_name=${MYSQL_MASTER_SERVICE_NAME:-mysql-master}
+  local endpoints=$(dig ${service_name} A +search +short 2>/dev/null)
+  # FIXME: This is for debugging (docker run)
+  if [ -v MYSQL_MASTER_IP ]; then
+    endpoints=${MYSQL_MASTER_IP-}
+  fi
+  echo -n "$(echo $endpoints | cut -d ' ' -f 1)"
+}
+
+function validate_replication_variables() {
+  if ! [[ -v MYSQL_MASTER_USER && -v MYSQL_MASTER_PASSWORD  ]]; then
+    echo
+    echo "For master/slave replication, you have to specify following environment variables:"
+    echo "  MYSQL_MASTER_USER"
+    echo "  MYSQL_MASTER_PASSWORD"
+    echo
+  fi
+  [[ "$MYSQL_MASTER_USER"     =~ $mysql_identifier_regex ]] || usage "Invalid MySQL master username"
+  [ ${#MYSQL_MASTER_USER} -le 16 ] || usage "MySQL master username too long (maximum 16 characters)"
+  [[ "$MYSQL_MASTER_PASSWORD" =~ $mysql_password_regex   ]] || usage "Invalid MySQL master password"
+}

--- a/5.6/contrib/my-master.cnf.template
+++ b/5.6/contrib/my-master.cnf.template
@@ -1,0 +1,11 @@
+[mysqld]
+
+server-id     = ${MYSQL_SERVER_ID}
+log_bin       = ${MYSQL_DATADIR}/mysql-bin.log
+binlog_do_db  = ${MYSQL_DATABASE}
+gtid_mode     = ON
+log-slave-updates = ON
+enforce-gtid-consistency = ON
+
+# Include the common MySQL settings
+!include ${HOME}/my-common.cnf

--- a/5.6/contrib/my-slave.cnf.template
+++ b/5.6/contrib/my-slave.cnf.template
@@ -1,0 +1,12 @@
+[mysqld]
+
+server-id     = ${MYSQL_SERVER_ID}
+log_bin       = ${MYSQL_DATADIR}/mysql-bin.log
+relay-log     = ${MYSQL_DATADIR}/mysql-relay-bin.log
+binlog_do_db  = ${MYSQL_DATABASE}
+gtid_mode     = ON
+log-slave-updates = ON
+enforce-gtid-consistency = ON
+
+# Include the common MySQL settings
+!include ${HOME}/my-common.cnf

--- a/5.6/contrib/my.cnf.template
+++ b/5.6/contrib/my.cnf.template
@@ -1,0 +1,32 @@
+[mysqld]
+user = mysql
+
+datadir = ${MYSQL_DATADIR}
+basedir = /opt/rh/rh-mysql56/root/usr
+plugin-dir = /opt/rh/rh-mysql56/root/usr/lib64/mysql/plugin
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links = 0
+
+# http://www.percona.com/blog/2008/05/31/dns-achilles-heel-mysql-installation/
+skip_name_resolve
+
+#
+# Settings configured by the user
+#
+
+# Sets how the table names are stored and compared. Default: 0
+lower_case_table_names = ${MYSQL_LOWER_CASE_TABLE_NAMES}
+
+# The maximum permitted number of simultaneous client connections. Default: 151
+max_connections = ${MYSQL_MAX_CONNECTIONS}
+
+# The minimum length of the word to be included in a FULLTEXT index. Default: 4
+ft_min_word_len = ${MYSQL_FT_MIN_WORD_LEN}
+
+# The maximum length of the word to be included in a FULLTEXT index. Default: 20
+ft_max_word_len = ${MYSQL_FT_MAX_WORD_LEN}
+
+# In case the native AIO is broken. Default: 1
+# See http://help.directadmin.com/item.php?id=529
+innodb_use_native_aio = ${MYSQL_AIO}

--- a/5.6/contrib/scl_enable
+++ b/5.6/contrib/scl_enable
@@ -1,0 +1,3 @@
+# This will make scl collection binaries work out of box.
+unset BASH_ENV PROMPT_COMMAND ENV
+source scl_source enable rh-mysql56

--- a/5.6/examples/replica/README.md
+++ b/5.6/examples/replica/README.md
@@ -1,0 +1,147 @@
+# MySQL Replication Example
+
+**WARNING:**
+
+**This is only a Proof-Of-Concept example and it is not meant to be used in any
+production. Use at your own risk.**
+
+## What is MySQL replication?
+
+Replication enables data from one MySQL database server (the master) to be
+replicated to one or more MySQL database servers (the slaves). Replication is
+asynchronous - slaves do not need not be connected permanently to receive updates from
+the master. This means that updates can occur over long-distance connections and
+even over temporary or intermittent connections such as a dial-up service.
+Depending on the configuration, you can replicate all databases, selected
+databases, or even selected tables within a database.
+
+See: https://dev.mysql.com/doc/refman/5.6/en/replication.html
+
+## How does this example work?
+
+The provided JSON file (`mysql_replica.json`) contains a `Template` resource that
+groups the Kubernetes and OpenShift resources which are meant to be created.
+This template will start with one MySQL master server and one slave server.
+
+## Persistent storage
+
+In order to provide the persistent storage for the MySQL master server, the administrator
+of OpenShift needs to create a PersistentVolume that you can claim. This example requires a PersistentVolume of size 512m be available.
+To learn more about how to create PersistentVolume, refer to [OpenShift documentation](https://docs.openshift.org/latest/admin_guide/persistent_storage_nfs.html)
+
+### Service 'mysql-master'
+
+This resource provides 'headless' Service for the MySQL server(s) which acts
+as the 'master'. The headless means that the Service does not use IP
+addresses but it uses the DNS sub-system. This behavior is configured by setting
+the `portalIP` attribute to `None`.
+
+In this case, you can query the DNS (eg. `dig mysql-master A +search +short`) to
+obtain the list of the Service endpoints (the MySQL servers that subscribe to
+this service).
+
+### Service 'mysql-slave'
+
+This resource provides the 'headless' Service for the MySQL servers that the
+MySQL master uses as 'slaves' which are used to replicate the data from the
+MySQL master.
+
+You can use the same DNS lookup as mentioned above to obtain the list of the
+Service endpoints.
+
+### ReplicationController 'mysql-master'
+
+This resource defines the `PodTemplate` of the MySQL server that acts as the
+'master'. The Pod uses the `openshift/mysql-56-centos7` image, but it sets the
+special 'entrypoint' named `mysqld-master`. This will tell the MySQL image to
+configure the MySQL server as the 'master'.
+
+To configure the 'master', you have to provide the credentials for the user that
+will act as the 'master' admin. This user has special privileges to add or
+remove 'slaves'.
+The other thing you have to provide is the regular MySQL username that you can
+use to connect to the MySQL server. This user has lower privileges and it is
+safe to use it in your application.
+
+Optionally you can define `MYSQL_DATABASE` and `MYSQL_ROOT_PASSWORD`. The first
+one sets the name of the initial database that will be created and the
+`MYSQL_USER` will be granted access to it. This parameter is optional
+and if you don't specify it, the database name will default to the value of
+`MYSQL_USER`.
+
+If you want to perform administration tasks, you can also set the
+`MYSQL_ROOT_PASSWORD`. In that case you will be able to connect to the MySQL
+server as the 'root' user and create more users or more databases.
+
+Once the MySQL master server is started, it has no slaves preconfigured as the
+slaves registers automatically.
+
+Note that currently the multiple-master configuration is not supported (even
+though the `mysql-master` is defined as ReplicationController. If you increase the
+number of replicas, then a new MySQL master server is started, but it will not
+receive any slaves. This will be solved in future.
+
+To check that the master MySQL server is working, you can issue the following
+command on the master container:
+
+```
+mysql> SHOW MASTER STATUS;
++------------------+----------+--------------+------------------+
+| File             | Position | Binlog_Do_DB | Binlog_Ignore_DB |
++------------------+----------+--------------+------------------+
+| mysql-bin.000002 |      107 | foo          |                  |
++------------------+----------+--------------+------------------+
+1 row in set (0.00 sec)
+```
+
+### ReplicationController 'mysql-slave'
+
+This resource defines the `PodTemplate` of the MySQL servers that act as the
+`slaves` to the `master` server. In the provided JSON example, this Replication
+Controller starts with 3 slaves. Each `slave` server first waits for the `master`
+server to become available (getting the `master` server IP using the DNS
+lookup). Once the `master` is available, the MySQL 'slave' server is started and
+connected to the `master`. The unique `server-id` configuration property is
+generated from the unique IP address of the container (and hashed to a number).
+Each `slave` must have unique `server-id`.
+
+Once the `slave` is running, it will fetch the database and users from the
+`master` server, so you don't have to configure the user accounts for this
+resources.
+
+To check the 'slave' status, you can issue the following command on the slave
+container:
+
+```
+mysql> SHOW SLAVE STATUS\G
+*************************** 1. row ***************************
+               Slave_IO_State: Waiting for master to send event
+                  Master_Host: 172.17.0.17
+                  Master_User: master
+                  Master_Port: 3306
+                Connect_Retry: 60
+```
+
+This output means that the 'slave' is successfully connected to the 'master'
+MySQL server running on '172.17.0.17'.
+
+To see the 'slave' hosts from the 'master', you can issue the following command
+on the 'master' container:
+
+```
+mysql> SHOW SLAVE HOSTS;
++------------+-------------+------+------------+
+| Server_id  | Host        | Port | Master_id  |
++------------+-------------+------+------------+
+| 3314680171 | 172.17.0.20 | 3306 | 1301393349 |
+| 3532875540 | 172.17.0.18 | 3306 | 1301393349 |
++------------+-------------+------+------------+
+2 rows in set (0.01 sec)
+
+```
+
+You can add more slaves if you want, using the following `oc` command.
+
+```
+$ oc scale rc mysql-slave --replicas=4
+```

--- a/5.6/examples/replica/mysql_replica.json
+++ b/5.6/examples/replica/mysql_replica.json
@@ -1,0 +1,295 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "mysql-replication-example",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "MySQL Replication Example",
+      "iconClass": "icon-database",
+      "tags": "database,mysql,replication"
+    }
+  },
+  "parameters": [
+    {
+      "name": "MYSQL_MASTER_USER",
+      "description": "The username used for master-slave replication",
+      "value": "master"
+    },
+    {
+      "name": "MYSQL_MASTER_PASSWORD",
+      "description": "The password for the MySQL master user",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{12}"
+    },
+    {
+      "name": "MYSQL_USER",
+      "description": "The username that clients will use to connect to MySQL server",
+      "value": "user"
+    },
+    {
+      "name": "MYSQL_PASSWORD",
+      "description": "The password for the MySQL master user",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{12}"
+    },
+    {
+      "name": "MYSQL_DATABASE",
+      "description": "The name of the database that will be created",
+      "value": "userdb"
+    },
+    {
+      "name": "MYSQL_ROOT_PASSWORD",
+      "description": "The password for the MySQL adminitrator",
+      "generate": "expression",
+      "from": "[a-zA-Z0-9]{12}"
+    }
+  ],
+  "objects": [
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql-master"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "512Mi"
+          }
+        }
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql-master",
+        "labels": {
+          "name": "mysql-master"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 3306,
+            "targetPort": 3306,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "mysql-master"
+        },
+        "portalIP": "None",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql-slave",
+        "labels": {
+          "name": "mysql-slave"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "protocol": "TCP",
+            "port": 3306,
+            "targetPort": 3306,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "mysql-slave"
+        },
+        "portalIP": "None",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql-master",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "mysql-master"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "mysql-master"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "mysql-master-data",
+                "persistentVolumeClaim": {
+                  "claimName": "mysql-master"
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "server",
+                "image": "openshift/mysql-56-centos7",
+                "command": [
+                  "run-mysqld-master.sh"
+                ],
+                "ports": [
+                  {
+                    "containerPort": 3306,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_MASTER_USER",
+                    "value": "${MYSQL_MASTER_USER}"
+                  },
+                  {
+                    "name": "MYSQL_MASTER_PASSWORD",
+                    "value": "${MYSQL_MASTER_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_USER",
+                    "value": "${MYSQL_USER}"
+                  },
+                  {
+                    "name": "MYSQL_PASSWORD",
+                    "value": "${MYSQL_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "${MYSQL_DATABASE}"
+                  },
+                  {
+                    "name": "MYSQL_ROOT_PASSWORD",
+                    "value": "${MYSQL_ROOT_PASSWORD}"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "mysql-master-data",
+                    "mountPath": "/var/lib/mysql/data"
+                  }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent",
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql-slave",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "mysql-slave"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "mysql-slave"
+            }
+          },
+          "spec": {
+            "containers": [
+              {
+                "name": "server",
+                "image": "openshift/mysql-56-centos7",
+                "command": [
+                  "run-mysqld-slave.sh"
+                ],
+                "ports": [
+                  {
+                    "containerPort": 3306,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                  {
+                    "name": "MYSQL_MASTER_USER",
+                    "value": "${MYSQL_MASTER_USER}"
+                  },
+                  {
+                    "name": "MYSQL_MASTER_PASSWORD",
+                    "value": "${MYSQL_MASTER_PASSWORD}"
+                  },
+                  {
+                    "name": "MYSQL_DATABASE",
+                    "value": "${MYSQL_DATABASE}"
+                  }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent",
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": false
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      },
+      "status": {}
+    }
+  ]
+}

--- a/5.6/examples/replica/teardown.sh
+++ b/5.6/examples/replica/teardown.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+oc update rc mysql-master --patch='{ "apiVersion": "v1beta1", "desiredState": { "replicas": 0 }}'
+oc update rc mysql-slave --patch='{ "apiVersion": "v1beta1", "desiredState": { "replicas": 0 }}'
+
+oc delete rc mysql-master
+oc delete rc mysql-slave
+
+oc delete service mysql-master
+oc delete service mysql-slave

--- a/5.6/examples/replica/volume.json
+++ b/5.6/examples/replica/volume.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolume",
+  "metadata": {
+    "name": "mysql-data"
+  },
+  "spec": {
+    "capacity": {
+        "storage": "512Mi"
+    },
+    "accessModes": [ "ReadWriteOnce" ],
+    "nfs": {
+        "path": "/storage",
+        "server": "192.168.124.206"
+    },
+    "persistentVolumeReclaimPolicy": "Recycle"
+  }
+}

--- a/5.6/run-mysqld-master.sh
+++ b/5.6/run-mysqld-master.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+#
+# This is an entrypoint that runs the MySQL server in the 'master' mode.
+#
+source ${HOME}/common.sh
+
+set -eu
+
+mysql_flags="-u root --socket=/tmp/mysql.sock"
+admin_flags="--defaults-file=$MYSQL_DEFAULTS_FILE $mysql_flags"
+
+validate_replication_variables
+validate_variables
+
+# Generate the unique 'server-id' for this master
+export MYSQL_SERVER_ID=$(server_id)
+echo "The 'master' server-id is ${MYSQL_SERVER_ID}"
+
+# Process the MySQL configuration files
+envsubst < $HOME/my.cnf.template > $HOME/my-common.cnf
+envsubst < $HOME/my-master.cnf.template > $MYSQL_DEFAULTS_FILE
+
+# Initialize MySQL database if this is the first time this containr runs and there
+# are no existing data. In other case just start the local mysql to allow editing
+# configuration
+if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
+  initialize_database
+else
+  start_local_mysql
+fi
+
+# Set the password for MySQL user and root everytime this container is started.
+# This allows to change the password by editing the deployment configuration.
+mysql $mysql_flags <<EOSQL
+  SET PASSWORD FOR '${MYSQL_USER}'@'%' = PASSWORD('${MYSQL_PASSWORD}');
+EOSQL
+
+# The MYSQL_ROOT_PASSWORD is optional
+if [ -v MYSQL_ROOT_PASSWORD ]; then
+mysql $mysql_flags <<EOSQL
+    SET PASSWORD FOR 'root'@'%' = PASSWORD('${MYSQL_ROOT_PASSWORD}');
+EOSQL
+fi
+
+# Setup the 'master' replication on the MySQL server
+mysql $mysql_flags <<EOSQL
+  GRANT REPLICATION SLAVE ON *.* TO '${MYSQL_MASTER_USER}'@'%' IDENTIFIED BY '${MYSQL_MASTER_PASSWORD}';
+  FLUSH PRIVILEGES;
+EOSQL
+
+# Restart the MySQL server with public IP bindings
+mysqladmin $admin_flags flush-privileges shutdown
+unset_env_vars
+exec /opt/rh/rh-mysql56/root/usr/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE "$@" 2>&1

--- a/5.6/run-mysqld-slave.sh
+++ b/5.6/run-mysqld-slave.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# This is an entrypoint that runs the MySQL server in the 'slave' mode.
+#
+source ${HOME}/common.sh
+
+set -eu
+
+mysql_flags="-u root --socket=/tmp/mysql.sock"
+admin_flags="--defaults-file=$MYSQL_DEFAULTS_FILE $mysql_flags"
+
+validate_replication_variables
+
+# Generate the unique 'server-id' for this master
+export MYSQL_SERVER_ID=$(server_id)
+echo "The 'slave' server-id is ${MYSQL_SERVER_ID}"
+
+# Process the MySQL configuration files
+envsubst < $HOME/my.cnf.template > $HOME/my-common.cnf
+envsubst < $HOME/my-slave.cnf.template > $MYSQL_DEFAULTS_FILE
+
+# Initialize MySQL database and wait for the MySQL master to accept connections
+# This will also disable the database and user creation (the data will be
+# fetched from the 'master' server).
+export MYSQL_DISABLE_CREATE_DB=1
+initialize_database
+wait_for_mysql_master
+
+mysql $mysql_flags <<EOSQL
+  CHANGE MASTER TO MASTER_HOST='$(mysql_master_addr)',MASTER_USER='${MYSQL_MASTER_USER}', MASTER_PASSWORD='${MYSQL_MASTER_PASSWORD}';
+EOSQL
+
+# Restart the MySQL server with public IP bindings
+mysqladmin $admin_flags flush-privileges shutdown
+unset_env_vars
+exec /opt/rh/rh-mysql56/root/usr/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE \
+  --report-host=$(hostname -i) "$@" 2>&1

--- a/5.6/run-mysqld.sh
+++ b/5.6/run-mysqld.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+source $HOME/common.sh
+set -eu
+
+mysql_flags="-u root --socket=/tmp/mysql.sock"
+admin_flags="--defaults-file=$MYSQL_DEFAULTS_FILE $mysql_flags"
+
+if [ "$1" == "mysqld-master" ] &&  [ ! -d "${MYSQL_DATADIR}/mysql" ]; then
+  shift
+  exec /usr/local/bin/run-mysqld-master.sh "$@"
+fi
+
+if [ "$1" == "mysqld-slave" ] &&  [ ! -d "${MYSQL_DATADIR}/mysql" ]; then
+  shift
+  exec /usr/local/bin/run-mysqld-slave.sh "$@"
+fi
+
+if [ "$1" == "mysqld" ]; then
+  validate_variables
+  envsubst < ${MYSQL_DEFAULTS_FILE}.template > $MYSQL_DEFAULTS_FILE
+
+  if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
+    initialize_database
+  else
+    start_local_mysql
+  fi
+
+# Set the password for MySQL user and root everytime this container is started.
+# This allows to change the password by editing the deployment configuration.
+mysql $mysql_flags <<EOSQL
+  SET PASSWORD FOR '${MYSQL_USER}'@'%' = PASSWORD('${MYSQL_PASSWORD}');
+EOSQL
+
+# The MYSQL_ROOT_PASSWORD is optional
+if [ -v MYSQL_ROOT_PASSWORD ]; then
+mysql $mysql_flags <<EOSQL
+    SET PASSWORD FOR 'root'@'%' = PASSWORD('${MYSQL_ROOT_PASSWORD}');
+EOSQL
+fi
+
+  mysqladmin $admin_flags flush-privileges shutdown
+
+  shift
+  unset_env_vars
+  exec /opt/rh/rh-mysql56/root/usr/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE "$@" 2>&1
+fi
+
+unset_env_vars
+exec "$@"

--- a/5.6/test/run
+++ b/5.6/test/run
@@ -9,7 +9,7 @@
 set -exo nounset
 shopt -s nullglob
 
-IMAGE_NAME=${IMAGE_NAME-openshift/mysql-55-centos7-candidate}
+IMAGE_NAME=${IMAGE_NAME-openshift/mysql-56-centos7-candidate}
 
 CIDFILE_DIR=$(mktemp --suffix=mysql_test_cidfiles -d)
 
@@ -269,7 +269,7 @@ function run_tests() {
   CONTAINER_IP=$(get_container_ip $name)
   test_connection $name
   echo "  Testing scl usage"
-  test_scl_usage $name 'mysql --version' '5.5'
+  test_scl_usage $name 'mysql --version' '5.6'
   echo "  Testing login accesses"
   assert_login_access $USER $PASS true
   assert_login_access $USER "${PASS}_foo" false

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 SKIP_SQUASH?=0
-VERSIONS="5.5"
+VERSIONS="5.5 5.6"
 
 ifeq ($(TARGET),rhel7)
 	OS := rhel7
@@ -9,6 +9,8 @@ endif
 
 ifeq ($(VERSION), 5.5)
 	VERSION := 5.5
+else ifeq ($(VERSION), 5.6)
+        VERSION := 5.6
 else
 	VERSION :=
 endif

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Versions
 ---------------
 MySQL versions currently provided are:
 * mysql-5.5
+* mysql-5.6
 
 RHEL versions currently supported are:
 * RHEL7
@@ -48,9 +49,12 @@ Choose either the CentOS7 or RHEL7 based image:
     $ make build VERSION=5.5
     ```
 
+For using other versions of mysql, just replace the `5.5` value by particular version
+in the commands above.
+
 **Notice: By omitting the `VERSION` parameter, the build/test action will be performed
-on all provided versions of MySQL. Since we are currently providing only version `5.5`,
-you can omit this parameter.**
+on all provided versions of MySQL, which must be specified in  `VERSIONS` variable.
+This variable must be set to a list with possible versions (subdirectories).**
 
 
 Environment variables and volumes
@@ -143,6 +147,9 @@ Users can choose between testing MySQL based on a RHEL or CentOS image.
     $ make test VERSION=5.5
     ```
 
+For using other versions of mysql, just replace the `5.5` value by particular version
+in the commands above.
+
 **Notice: By omitting the `VERSION` parameter, the build/test action will be performed
-on all provided versions of MySQL. Since we are currently providing only version `5.5`,
-you can omit this parameter.**
+on all provided versions of MySQL, which must be specified in  `VERSIONS` variable.
+This variable must be set to a list with possible versions (subdirectories).**


### PR DESCRIPTION
This is initial commit to add mysql 5.6 based image. One commit just changes the packages the image is based on, another commit changes replication implementation to use GTID, which allows easier replication management (no binlog files/locations needed).