### PR TITLE
Refactor ./hack/build.sh and add LABEL with image version

### DIFF
--- a/5.5/examples/replica/volume.json
+++ b/5.5/examples/replica/volume.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "v1",
+  "kind": "PersistentVolume",
+  "metadata": {
+    "name": "mysql-data"
+  },
+  "spec": {
+    "capacity": {
+        "storage": "512Mi"
+    },
+    "accessModes": [ "ReadWriteOnce" ],
+    "nfs": {
+        "path": "/storage",
+        "server": "192.168.124.206"
+    },
+    "persistentVolumeReclaimPolicy": "Recycle"
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 SKIP_SQUASH?=0
+VERSIONS="5.5"
 
 ifeq ($(TARGET),rhel7)
 	OS := rhel7
@@ -14,10 +15,8 @@ endif
 
 .PHONY: build
 build:
-	SKIP_SQUASH=$(SKIP_SQUASH) hack/build.sh $(OS) $(VERSION)
-
+	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) hack/build.sh $(OS) $(VERSION)
 
 .PHONY: test
 test:
-	SKIP_SQUASH=$(SKIP_SQUASH) TEST_MODE=true hack/build.sh $(OS) $(VERSION)
-
+	SKIP_SQUASH=$(SKIP_SQUASH) VERSIONS=$(VERSIONS) TEST_MODE=true hack/build.sh $(OS) $(VERSION)

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,51 +1,71 @@
 #!/bin/bash -e
-# $1 - Specifies distribution - RHEL7/CentOS7
-# $2 - Specifies MySQL version - 5.5
+# This script is used to build, test and squash the OpenShift Docker images.
+#
+# $1 - Specifies distribution - "rhel7" or "centos7"
+# $2 - Specifies the image version - (must match with subdirectory in repo)
 # TEST_MODE - If set, build a candidate image and test it
-
-# Array of all versions of MySQL
-declare -a VERSIONS=(5.5)
+# VERSIONS - Must be set to a list with possible versions (subdirectories)
 
 OS=$1
 VERSION=$2
 
-function squash {
-  # install the docker layer squashing tool
-  easy_install --user docker_py==1.2.3 docker-scripts==0.4.2
-  base=$(awk '/^FROM/{print $2}' $1)
-  $HOME/.local/bin/docker-scripts squash -f $base ${IMAGE_NAME}
+DOCKERFILE_PATH=""
+BASE_DIR_NAME=$(basename `pwd`)
+BASE_IMAGE_NAME="openshift/${BASE_DIR_NAME#sti-}"
+
+# Cleanup the temporary Dockerfile created by docker build with version
+trap 'remove_tmp_dockerfile' SIGINT SIGQUIT EXIT
+function remove_tmp_dockerfile {
+  if [[ ! -z "${DOCKERFILE_PATH}.version" ]]; then
+    rm -f "${DOCKERFILE_PATH}.version"
+  fi
 }
 
-if [ -z ${VERSION} ]; then
-  # Build all versions
-  dirs=${VERSIONS}
-else
-  # Build only specified version on MySQL
-  dirs=${VERSION}
-fi
+# Perform docker build but append the LABEL with GIT commit id at the end
+function docker_build_with_version {
+  local dockerfile="$1"
+  # Use perl here to make this compatible with OSX
+  DOCKERFILE_PATH=$(perl -MCwd -e 'print Cwd::abs_path shift' $dockerfile)
+  cp ${DOCKERFILE_PATH} "${DOCKERFILE_PATH}.version"
+  git_version=$(git rev-parse --short HEAD)
+  echo "LABEL io.openshift.builder-version=\"${git_version}\"" >> "${dockerfile}.version"
+  docker build -t ${IMAGE_NAME} -f "${dockerfile}.version" .
+  if [[ "${SKIP_SQUASH}" != "1" ]]; then
+    squash "${dockerfile}.version"
+  fi
+}
+
+# Install the docker squashing tool[1] and squash the result image
+# [1] https://github.com/goldmann/docker-scripts
+function squash {
+  # FIXME: We have to use the exact versions here to avoid Docker client
+  #        compatibility issues
+  easy_install -q --user docker_py==1.2.3 docker-scripts==0.4.2
+  base=$(awk '/^FROM/{print $2}' $1)
+  ${HOME}/.local/bin/docker-scripts squash -f $base ${IMAGE_NAME}
+}
+
+# Versions are stored in subdirectories. You can specify VERSION variable
+# to build just one single version. By default we build all versions
+dirs=${VERSION:-$VERSIONS}
 
 for dir in ${dirs}; do
-  IMAGE_NAME=openshift/mysql-${dir//./}-${OS}
-  if [ -v TEST_MODE ]; then
-    IMAGE_NAME="${IMAGE_NAME}-candidate"
+  IMAGE_NAME="${BASE_IMAGE_NAME}-${dir//./}-${OS}"
+
+  if [[ -v TEST_MODE ]]; then
+    IMAGE_NAME+="-candidate"
   fi
-  echo ">>>> Building ${IMAGE_NAME}"
+
+  echo "-> Building ${IMAGE_NAME} ..."
 
   pushd ${dir} > /dev/null
-
   if [ "$OS" == "rhel7" -o "$OS" == "rhel7-candidate" ]; then
-    docker build -t ${IMAGE_NAME} -f Dockerfile.rhel7 .
-    if [ "${SKIP_SQUASH}" -ne "1" ]; then
-      squash Dockerfile.rhel7
-    fi
+    docker_build_with_version Dockerfile.rhel7
   else
-    docker build -t ${IMAGE_NAME} .
-    if [ "${SKIP_SQUASH}" -ne "1" ]; then
-      squash Dockerfile
-    fi
+    docker_build_with_version Dockerfile
   fi
 
-  if [ -v TEST_MODE ]; then
+  if [[ -v TEST_MODE ]]; then
     IMAGE_NAME=${IMAGE_NAME} test/run
   fi
 


### PR DESCRIPTION
This will:

* Make the ./hack/build.sh generic and copy&pastable across all repos
* Add `io.openshift.image-version` LABEL with value set to current GIT commit id (so we can identify later from which commit the image was build)
* Some general cleanup to Makefile/build.sh