### PR TITLE
Remove shifts

### DIFF
--- a/5.5/run-mysqld-master.sh
+++ b/5.5/run-mysqld-master.sh
@@ -4,7 +4,6 @@
 #
 source ${HOME}/common.sh
 set -eu
-shift
 
 mysql_flags="-u root --socket=/tmp/mysql.sock"
 admin_flags="--defaults-file=$MYSQL_DEFAULTS_FILE $mysql_flags"

--- a/5.5/run-mysqld-slave.sh
+++ b/5.5/run-mysqld-slave.sh
@@ -4,7 +4,6 @@
 #
 source ${HOME}/common.sh
 set -eu
-shift
 
 mysql_flags="-u root --socket=/tmp/mysql.sock"
 admin_flags="--defaults-file=$MYSQL_DEFAULTS_FILE $mysql_flags"

--- a/5.6/run-mysqld-master.sh
+++ b/5.6/run-mysqld-master.sh
@@ -4,7 +4,6 @@
 #
 source ${HOME}/common.sh
 set -eu
-shift
 
 mysql_flags="-u root --socket=/tmp/mysql.sock"
 admin_flags="--defaults-file=$MYSQL_DEFAULTS_FILE $mysql_flags"

--- a/5.6/run-mysqld-slave.sh
+++ b/5.6/run-mysqld-slave.sh
@@ -4,7 +4,6 @@
 #
 source ${HOME}/common.sh
 set -eu
-shift
 
 mysql_flags="-u root --socket=/tmp/mysql.sock"
 admin_flags="--defaults-file=$MYSQL_DEFAULTS_FILE $mysql_flags"


### PR DESCRIPTION
The slave and master replicas do not expect commands. This caused replication containers to not run, as found by QE.

@mfojtik @mdshuai