### PR TITLE
WIP: Fix replication and add OpenShift tests

### DIFF
--- a/5.5/contrib/common.sh
+++ b/5.5/contrib/common.sh
@@ -86,10 +86,10 @@ function initialize_database() {
   mysql_install_db --datadir=$MYSQL_DATADIR
   start_local_mysql "$@"
 
-  [ -v MYSQL_DISABLE_CREATE_DB ] && return
-
   mysqladmin $admin_flags -f drop test
   mysqladmin $admin_flags create "${MYSQL_DATABASE}"
+
+  [ -v MYSQL_DISABLE_CREATE_DB ] && return
 
 mysql $mysql_flags <<EOSQL
     CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';

--- a/5.5/examples/replica/nfs-pv-provider.json
+++ b/5.5/examples/replica/nfs-pv-provider.json
@@ -1,0 +1,231 @@
+{
+  "kind": "Template",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "nfs-pv-provider",
+    "creationTimestamp": null,
+    "annotations": {
+      "description": "NFS Persitent Volume provider",
+      "iconClass": "icon-database",
+      "tags": "storage"
+    }
+  },
+  "parameters": [
+    {
+      "name": "MYSQL_MASTER_USER",
+      "description": "The username used for master-slave replication",
+      "value": "master"
+    }
+  ],
+  "objects": [
+    {
+      "kind": "Service",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nfs",
+        "labels": {
+          "name": "nfs"
+        }
+      },
+      "spec": {
+        "ports": [
+          {
+            "name": "rpcbind",
+            "protocol": "UDP",
+            "port": 111,
+            "targetPort": 111,
+            "nodePort": 0
+          },
+          {
+            "name": "nfs",
+            "protocol": "TCP",
+            "port": 2049,
+            "targetPort": 2049,
+            "nodePort": 0
+          }
+        ],
+        "selector": {
+          "name": "nfs"
+        },
+        "portalIP": "None",
+        "type": "ClusterIP",
+        "sessionAffinity": "None"
+      },
+      "status": {
+        "loadBalancer": {}
+      }
+    },
+    {
+      "kind": "DeploymentConfig",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "nfs",
+        "creationTimestamp": null
+      },
+      "spec": {
+        "strategy": {
+          "type": "Recreate",
+          "resources": {}
+        },
+        "triggers": [
+          {
+            "type": "ConfigChange"
+          }
+        ],
+        "replicas": 1,
+        "selector": {
+          "name": "nfs"
+        },
+        "template": {
+          "metadata": {
+            "creationTimestamp": null,
+            "labels": {
+              "name": "nfs"
+            }
+          },
+          "spec": {
+            "volumes": [
+              {
+                "name": "nfs-data",
+                "emptyDir": {
+                  "medium": ""
+                }
+              }
+            ],
+            "containers": [
+              {
+                "name": "nfs",
+                "image": "mnagy/nfs-server",
+                "args": [
+                  "/exports/01",
+                  "/exports/02",
+                  "/exports/03",
+                  "/exports/04",
+                  "/exports/05"
+                ],
+                "ports": [
+                  {
+                    "containerPort": 111,
+                    "protocol": "UDP"
+                  },
+                  {
+                    "containerPort": 2049,
+                    "protocol": "TCP"
+                  }
+                ],
+                "env": [
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "nfs-data",
+                    "mountPath": "/exports"
+                  }
+                ],
+                "resources": {},
+                "terminationMessagePath": "/dev/termination-log",
+                "imagePullPolicy": "IfNotPresent",
+                "securityContext": {
+                  "capabilities": {},
+                  "privileged": true
+                }
+              }
+            ],
+            "restartPolicy": "Always",
+            "dnsPolicy": "ClusterFirst"
+          }
+        }
+      },
+      "status": {}
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolume",
+      "metadata": {
+        "name": "nfs01"
+      },
+      "spec": {
+        "capacity": {
+            "storage": "512Mi"
+        },
+        "accessModes": [ "ReadWriteOnce" ],
+        "nfs": {
+            "path": "/exports/01",
+            "server": "nfs.replication.svc.cluster.local"
+        },
+        "persistentVolumeReclaimPolicy": "Recycle"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolume",
+      "metadata": {
+        "name": "nfs02"
+      },
+      "spec": {
+        "capacity": {
+            "storage": "512Mi"
+        },
+        "accessModes": [ "ReadWriteOnce" ],
+        "nfs": {
+            "path": "/exports/02",
+            "server": "nfs.replication.svc.cluster.local"
+        },
+        "persistentVolumeReclaimPolicy": "Recycle"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolume",
+      "metadata": {
+        "name": "nfs03"
+      },
+      "spec": {
+        "capacity": {
+            "storage": "512Mi"
+        },
+        "accessModes": [ "ReadWriteOnce" ],
+        "nfs": {
+            "path": "/exports/03",
+            "server": "nfs.replication.svc.cluster.local"
+        },
+        "persistentVolumeReclaimPolicy": "Recycle"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolume",
+      "metadata": {
+        "name": "nfs04"
+      },
+      "spec": {
+        "capacity": {
+            "storage": "512Mi"
+        },
+        "accessModes": [ "ReadWriteOnce" ],
+        "nfs": {
+            "path": "/exports/04",
+            "server": "nfs.replication.svc.cluster.local"
+        },
+        "persistentVolumeReclaimPolicy": "Recycle"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "PersistentVolume",
+      "metadata": {
+        "name": "nfs05"
+      },
+      "spec": {
+        "capacity": {
+            "storage": "512Mi"
+        },
+        "accessModes": [ "ReadWriteOnce" ],
+        "nfs": {
+            "path": "/exports/05",
+            "server": "nfs.replication.svc.cluster.local"
+        },
+        "persistentVolumeReclaimPolicy": "Recycle"
+      }
+    }
+  ]
+}

--- a/5.5/test/common.sh
+++ b/5.5/test/common.sh
@@ -1,21 +1,36 @@
-#!/bin/bash
-#
-# Test the MySQL image.
+# Test helper functions.
 #
 # IMAGE_NAME specifies the name of the candidate image used for testing.
 # The image has to be available before this script is executed.
 #
 
-# Replication tests with OpenShift
-exec "test/test_replication.sh"
+function cleanup() {
+  for cidfile in $CIDFILE_DIR/* ; do
+    CONTAINER=$(cat $cidfile)
 
-set -exo nounset
-shopt -s nullglob
+    echo "Stopping and removing container $CONTAINER..."
+    docker stop $CONTAINER
+    exit_status=$(docker inspect -f '{{.State.ExitCode}}' $CONTAINER)
+    if [ "$exit_status" != "0" ]; then
+      echo "Dumping logs for $CONTAINER"
+      docker logs $CONTAINER
+    fi
+    docker rm $CONTAINER
+    rm $cidfile
+    echo "Done."
+  done
+  rmdir $CIDFILE_DIR
+}
 
-export IMAGE_NAME=${IMAGE_NAME-openshift/mysql-55-centos7-candidate}
-export CIDFILE_DIR=$(mktemp --suffix=mysql_test_cidfiles -d)
-source "test/common.sh"
-trap cleanup EXIT SIGINT
+function get_cid() {
+  local id="$1" ; shift || return 1
+  echo $(cat "$CIDFILE_DIR/$id")
+}
+
+function get_container_ip() {
+  local id="$1" ; shift
+  docker inspect --format='{{.NetworkSettings.IPAddress}}' $(get_cid "$id")
+}
 
 function mysql_cmd() {
   docker run --rm $IMAGE_NAME mysql --host $CONTAINER_IP -u$USER -p"$PASS" "$@" db
@@ -92,14 +107,12 @@ function run_replication_test() {
   # Run the MySQL master
   docker run $cluster_args -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
     -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=db \
-    -d --cidfile ${CIDFILE_DIR}/master.cid $IMAGE_NAME mysqld-master \
-    --innodb_buffer_pool_size=5242880
+    -d --cidfile ${CIDFILE_DIR}/master.cid $IMAGE_NAME mysqld-master
   master_ip=$(get_container_ip master.cid)
 
   # Run the MySQL slave
   docker run $cluster_args -e MYSQL_MASTER_IP=${master_ip} \
-    -d --cidfile ${CIDFILE_DIR}/slave.cid $IMAGE_NAME mysqld-slave \
-    --innodb_buffer_pool_size=5242880
+    -d --cidfile ${CIDFILE_DIR}/slave.cid $IMAGE_NAME mysqld-slave
   slave_ip=$(get_container_ip slave.cid)
 
   # Now wait till the MASTER will see the SLAVE
@@ -208,6 +221,21 @@ test_scl_usage() {
     echo "ERROR[/bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
     return 1
   fi
+  # out=$(docker run --rm -i ${IMAGE_NAME} /bin/bash -i <<< "${run_cmd}")
+  # if ! echo "${out}" | grep -q "${expected}"; then
+  #   echo "ERROR[-i /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+  #   return 1
+  # fi
+  # out=$(docker run --rm -i ${IMAGE_NAME} /bin/bash -l <<< "${run_cmd}")
+  # if ! echo "${out}" | grep -q "${expected}"; then
+  #   echo "ERROR[-i /bin/bash -l "${run_cmd}"] Expected '${expected}', got '${out}'"
+  #   return 1
+  # fi
+  # out=$(docker run --rm -i ${IMAGE_NAME} /bin/sh -ic "${run_cmd}")
+  # if ! echo "${out}" | grep -q "${expected}"; then
+  #   echo "ERROR[/bin/sh -c "${run_cmd}"] Expected '${expected}', got '${out}'"
+  #   return 1
+  # fi
   out=$(docker exec $(get_cid $name) /bin/bash -c "${run_cmd}" 2>&1)
   if ! echo "${out}" | grep -q "${expected}"; then
     echo "ERROR[exec /bin/bash -c "${run_cmd}"] Expected '${expected}', got '${out}'"
@@ -256,7 +284,7 @@ run_container_creation_tests
 # run_configuration_tests
 
 # Set lower buffer pool size to avoid running out of memory.
-export CONTAINER_ARGS="mysqld --innodb_buffer_pool_size=5242880"
+export CONTAINER_ARGS="mysqld --innodb_buffer_pool_size=10485760"
 
 # Normal tests
 USER=user PASS=pass run_tests no_root
@@ -270,3 +298,6 @@ run_change_password_test
 
 # Replication tests
 run_replication_test
+
+# Replication tests with OpenShift
+./test_replication.sh

--- a/5.5/test/run
+++ b/5.5/test/run
@@ -6,14 +6,15 @@
 # The image has to be available before this script is executed.
 #
 
-# Replication tests with OpenShift
-exec "test/test_replication.sh"
-
 set -exo nounset
 shopt -s nullglob
 
 export IMAGE_NAME=${IMAGE_NAME-openshift/mysql-55-centos7-candidate}
 export CIDFILE_DIR=$(mktemp --suffix=mysql_test_cidfiles -d)
+
+# Replication tests with OpenShift
+exec "test/test_replication.sh"
+
 source "test/common.sh"
 trap cleanup EXIT SIGINT
 

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -74,6 +74,10 @@ function start_openshift() {
       --loglevel=5
 }
 
+function dump_logs() {
+  docker logs openshift-origin
+}
+
 #
 # Helper functions to run commands inside of the OpenShift Docker container.
 #
@@ -112,12 +116,8 @@ cat examples/replica/mysql_replica.json | run_interactive "oc process -f - | oc 
 
 # Wait until master and slave are up.
 #set +x
-sleep 30
-dig "mysql-master.replication.svc.cluster.local"
-dig "@${HOST_DOCKER_IP}" "mysql-master.replication.svc.cluster.local"
-dig "mysql-master.replication.svc.cluster.local."
-dig "@${HOST_DOCKER_IP}" "mysql-master.replication.svc.cluster.local."
 echo "Waiting for MySQL Master and Replica to come online"
+trap dump_logs ERR
 wait_for_url_timed "mysql-master.replication.svc.cluster.local:3306" "" 5*TIME_MIN >/dev/null
 wait_for_url_timed "mysql-slave.replication.svc.cluster.local:3306" "" 1*TIME_MIN >/dev/null
 set -x

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+set -eux
+
+TIME_SEC=1000
+TIME_MIN=$((60 * $TIME_SEC))
+HOST_DOCKER_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
+OPENSHIFT_CONFIG_DIR="/tmp/openshift-config"
+
+# time_now return the time since the epoch in millis
+function time_now()
+{
+  echo $(date +%s000)
+}
+
+# wait_for_url_timed attempts to access a url in order to
+# determine if it is available to service requests.
+#
+# $1 - The URL to check
+# $2 - Optional prefix to use when echoing a successful result
+# $3 - Optional maximum time to wait before giving up (Default: 10s)
+function wait_for_url_timed {
+  STARTTIME=$(date +%s)
+  url=$1
+  prefix=${2:-}
+  max_wait=${3:-10*TIME_SEC}
+  wait=0.2
+  expire=$(($(time_now) + $max_wait))
+  set +e
+  while [[ $(time_now) -lt $expire ]]; do
+    out=$(curl -k --max-time 2 -fs $url 2>/dev/null)
+    if [ $? -eq 0 ]; then
+      set -e
+      echo ${prefix}${out}
+      ENDTIME=$(date +%s)
+      echo "[INFO] Success accessing '$url' after $(($ENDTIME - $STARTTIME)) seconds"
+      return 0
+    fi
+    sleep $wait
+  done
+  echo "ERROR: gave up waiting for $url"
+  set -e
+  return 1
+}
+
+function setup_dns() {
+  # Make ourselves the default resolver. This is needes so FQDNs such as
+  # "pod-name.namespace.svc.cluster.local" can be resolved.
+  if ! grep -q $HOST_DOCKER_IP /etc/resolv.conf; then
+    sed -i "1inameserver $HOST_DOCKER_IP" /etc/resolv.conf
+  fi
+
+  sudo rm -rf $OPENSHIFT_CONFIG_DIR
+  # Generate openshift config file and edit the node config with DNS pointing to us.
+  docker run --rm -ti --privileged --net=host \
+    -v $OPENSHIFT_CONFIG_DIR:/config \
+    openshift/origin start --write-config=/config
+  sudo sed -i "s/dnsIP: .*/dnsIP: $HOST_DOCKER_IP/" $OPENSHIFT_CONFIG_DIR/node-openshiftdev.local/node-config.yaml
+}
+
+# Start openshift. We're using local generated config file that has DNS updated.
+function start_openshift() {
+  docker run -d --name "openshift-origin" \
+    --privileged --net=host \
+    -v /:/rootfs:ro -v /var/run:/var/run:rw -v /sys:/sys:ro -v /var/lib/docker:/var/lib/docker:rw \
+    -v $OPENSHIFT_CONFIG_DIR:/var/lib/openshift/openshift.local.config \
+    -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes \
+    openshift/origin start \
+      --master-config=/var/lib/openshift/openshift.local.config/master/master-config.yaml \
+      --node-config=/var/lib/openshift/openshift.local.config/node-openshiftdev.local/node-config.yaml \
+      --loglevel=5
+}
+
+#
+# Helper functions to run commands inside of the OpenShift Docker container.
+#
+function run() {
+  docker exec openshift-origin /bin/bash -c "$@"
+}
+
+function run_interactive() {
+  docker exec -i openshift-origin /bin/bash -c "$@"
+}
+
+
+# Main
+setup_dns
+start_openshift
+set +x
+echo "Waiting for OpenShift to start ..."
+wait_for_url_timed "https://${HOST_DOCKER_IP}:8443/healthz" "" 90*TIME_SEC >/dev/null
+set -x
+
+# Install mysql command line tool so we can make test queries.
+run "yum -y install mysql"
+
+# Create new project.
+run "oc new-project replication"
+
+# Allow all pods to run as privileged, so NFS server works.
+# FIXME: There doesn't seem to be a nice way to simply add a new user to an SCC
+run "oc patch scc privileged -p '{\"users\":[\"system:serviceaccount:openshift-infra:build-controller\",\"system:serviceaccount:replication:default\"]}'"
+
+# Create Persistent Volumes backed by NFS.
+cat examples/replica/nfs-pv-provider.json | run_interactive "oc process -f - | oc create -f -"
+
+# Now create MySQL replica scenario.
+cat examples/replica/mysql_replica.json | run_interactive "oc process -f - | oc create -f -"
+
+# Wait until master and slave are up.
+set +x
+echo "Waiting for MySQL Master and Replica to come online"
+wait_for_url_timed "mysql-master.replication.svc.cluster.local:3306" "" 3*TIME_MIN >/dev/null
+wait_for_url_timed "mysql-slave.replication.svc.cluster.local:3306" "" 1*TIME_MIN >/dev/null
+set -x
+
+# Get environment variables from master, so we know the passwords.
+export $(run "oc env --list dc mysql-master | grep -v '^#'")
+
+#
+# Tests start here.
+#
+
+# Create table in master.
+run_interactive "mysql -h mysql-master.replication.svc.cluster.local -u${MYSQL_USER} -p${MYSQL_PASSWORD} ${MYSQL_DATABASE}" <<EOF
+CREATE TABLE tbl (col1 VARCHAR(20), col2 VARCHAR(20));
+INSERT INTO tbl VALUES ('foo1', 'bar1');
+EOF
+
+sleep 2
+
+# FIXME: Should log in as normal user, doesn't work right now.
+# Verify that values are replicated in slave.
+SLAVE_POD_NAME=$(run "oc get pods | grep mysql-slave | cut -f 1 -d ' '" | head -n 1)
+run "oc exec $SLAVE_POD_NAME -- /bin/bash -c 'mysql -uroot ${MYSQL_DATABASE} -e \"SELECT * FROM tbl;\"'" | grep -q foo1
+
+echo "All tests finished successfully"

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -109,7 +109,7 @@ cat examples/replica/nfs-pv-provider.json | run_interactive "oc process -f - | o
 cat examples/replica/mysql_replica.json | run_interactive "oc process -f - | oc create -f -"
 
 # Wait until master and slave are up.
-set +x
+#set +x
 echo "Waiting for MySQL Master and Replica to come online"
 wait_for_url_timed "mysql-master.replication.svc.cluster.local:3306" "" 5*TIME_MIN >/dev/null
 wait_for_url_timed "mysql-slave.replication.svc.cluster.local:3306" "" 1*TIME_MIN >/dev/null

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -111,7 +111,7 @@ cat examples/replica/mysql_replica.json | run_interactive "oc process -f - | oc 
 # Wait until master and slave are up.
 set +x
 echo "Waiting for MySQL Master and Replica to come online"
-wait_for_url_timed "mysql-master.replication.svc.cluster.local:3306" "" 3*TIME_MIN >/dev/null
+wait_for_url_timed "mysql-master.replication.svc.cluster.local:3306" "" 5*TIME_MIN >/dev/null
 wait_for_url_timed "mysql-slave.replication.svc.cluster.local:3306" "" 1*TIME_MIN >/dev/null
 set -x
 

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -48,11 +48,10 @@ function setup_dns() {
   # Make ourselves the default resolver. This is needes so FQDNs such as
   # "pod-name.namespace.svc.cluster.local" can be resolved.
   if ! grep -q $HOST_DOCKER_IP /etc/resolv.conf; then
-    sed -i "1inameserver $HOST_DOCKER_IP" /etc/resolv.conf
+    sudo sed -i "1inameserver $HOST_DOCKER_IP" /etc/resolv.conf
   fi
 
   cat /etc/resolv.conf
-  exit 1
 
   sudo rm -rf $OPENSHIFT_CONFIG_DIR
   # Generate openshift config file and edit the node config with DNS pointing to us.

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -52,7 +52,7 @@ function setup_dns() {
 
   sudo rm -rf $OPENSHIFT_CONFIG_DIR
   # Generate openshift config file and edit the node config with DNS pointing to us.
-  docker run --rm -ti --privileged --net=host \
+  docker run --rm -i --privileged --net=host \
     -v $OPENSHIFT_CONFIG_DIR:/config \
     openshift/origin start --write-config=/config
   sudo sed -i "s/dnsIP: .*/dnsIP: $HOST_DOCKER_IP/" $OPENSHIFT_CONFIG_DIR/node-openshiftdev.local/node-config.yaml

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -51,6 +51,9 @@ function setup_dns() {
     sed -i "1inameserver $HOST_DOCKER_IP" /etc/resolv.conf
   fi
 
+  cat /etc/resolv.conf
+  exit 1
+
   sudo rm -rf $OPENSHIFT_CONFIG_DIR
   # Generate openshift config file and edit the node config with DNS pointing to us.
   docker run --rm -i --privileged --net=host \

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -6,6 +6,7 @@ TIME_SEC=1000
 TIME_MIN=$((60 * $TIME_SEC))
 HOST_DOCKER_IP=$(ip -4 addr show docker0 | grep -Po 'inet \K[\d.]+')
 OPENSHIFT_CONFIG_DIR="/tmp/openshift-config"
+OPENSHIFT_NODE_CONFIG="node-`hostname`/node-config.yaml"
 
 # time_now return the time since the epoch in millis
 function time_now()
@@ -55,7 +56,7 @@ function setup_dns() {
   docker run --rm -i --privileged --net=host \
     -v $OPENSHIFT_CONFIG_DIR:/config \
     openshift/origin start --write-config=/config
-  sudo sed -i "s/dnsIP: .*/dnsIP: $HOST_DOCKER_IP/" $OPENSHIFT_CONFIG_DIR/node-openshiftdev.local/node-config.yaml
+  sudo sed -i "s/dnsIP: .*/dnsIP: $HOST_DOCKER_IP/" $OPENSHIFT_CONFIG_DIR/$OPENSHIFT_NODE_CONFIG
 }
 
 # Start openshift. We're using local generated config file that has DNS updated.
@@ -67,7 +68,7 @@ function start_openshift() {
     -v /var/lib/openshift/openshift.local.volumes:/var/lib/openshift/openshift.local.volumes \
     openshift/origin start \
       --master-config=/var/lib/openshift/openshift.local.config/master/master-config.yaml \
-      --node-config=/var/lib/openshift/openshift.local.config/node-openshiftdev.local/node-config.yaml \
+      --node-config=/var/lib/openshift/openshift.local.config/$OPENSHIFT_NODE_CONFIG \
       --loglevel=5
 }
 

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -112,6 +112,11 @@ cat examples/replica/mysql_replica.json | run_interactive "oc process -f - | oc 
 
 # Wait until master and slave are up.
 #set +x
+sleep 30
+dig "mysql-master.replication.svc.cluster.local"
+dig "@${HOST_DOCKER_IP}" "mysql-master.replication.svc.cluster.local"
+dig "mysql-master.replication.svc.cluster.local."
+dig "@${HOST_DOCKER_IP}" "mysql-master.replication.svc.cluster.local."
 echo "Waiting for MySQL Master and Replica to come online"
 wait_for_url_timed "mysql-master.replication.svc.cluster.local:3306" "" 5*TIME_MIN >/dev/null
 wait_for_url_timed "mysql-slave.replication.svc.cluster.local:3306" "" 1*TIME_MIN >/dev/null

--- a/5.5/test/test_replication.sh
+++ b/5.5/test/test_replication.sh
@@ -93,6 +93,8 @@ function run_interactive() {
 # Main
 setup_dns
 start_openshift
+# FIXME
+yum -y install nfs-utils
 set +x
 echo "Waiting for OpenShift to start ..."
 wait_for_url_timed "https://${HOST_DOCKER_IP}:8443/healthz" "" 90*TIME_SEC >/dev/null


### PR DESCRIPTION
This script fixes the MySQL replication by creating the $MYSQL_DATABASE on the slave, so the bin log will be able to catch on. It also adds a test script that runs OpenShift inside of a Docker container and tests the replication scenario (our example template). It also makes use of a nfs-server image that I created in order to provide Persistent Volumes.

Please ignore `test/run` and `test/common.sh`, I'm going to refactor and change them later, right now I just hacked it quickly so I'll see how Jenkins will run the tests.