### PR TITLE
Change remove_tmp_dockerfile

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -16,12 +16,7 @@ BASE_DIR_NAME=$(echo $(basename `pwd`) | sed -e 's/-[0-9]*$//g')
 BASE_IMAGE_NAME="openshift/${BASE_DIR_NAME#sti-}"
 
 # Cleanup the temporary Dockerfile created by docker build with version
-trap 'remove_tmp_dockerfile' SIGINT SIGQUIT EXIT
-function remove_tmp_dockerfile {
-  if [[ ! -z "${DOCKERFILE_PATH}.version" ]]; then
-    rm -f "${DOCKERFILE_PATH}.version"
-  fi
-}
+trap "rm -f ${DOCKERFILE_PATH}.version" SIGINT SIGQUIT EXIT
 
 # Perform docker build but append the LABEL with GIT commit id at the end
 function docker_build_with_version {
@@ -35,6 +30,7 @@ function docker_build_with_version {
   if [[ "${SKIP_SQUASH}" != "1" ]]; then
     squash "${dockerfile}.version"
   fi
+  rm -f "${DOCKERFILE_PATH}.version"
 }
 
 # Install the docker squashing tool[1] and squash the result image


### PR DESCRIPTION
The `-z` flag returns `true` if a string length is 0. `[ ! -z "$var" ]` is equivalent to `[ -n "$var" ]` or `[ "$string" ]` and in either case is not testing what is necessary here - because the string in question, `"${DOCKERFILE_PATH}.version"`, will *never* be of length 0, this `if` statement is not doing much.

Furthermore, this trap only removes the last `Dockerfile` used for `docker build`, and when running a  naked `make` command, multiple `docker build`s are run.