### PR TITLE
Ensure passwords match env vars

### DIFF
--- a/5.5/run-mysqld.sh
+++ b/5.5/run-mysqld.sh
@@ -32,10 +32,20 @@ mysql $mysql_flags <<EOSQL
   SET PASSWORD FOR '${MYSQL_USER}'@'%' = PASSWORD('${MYSQL_PASSWORD}');
 EOSQL
 
-# The MYSQL_ROOT_PASSWORD is optional
+# The MYSQL_ROOT_PASSWORD is optional, therefore we need to either enable remote
+# access with a password if the variable is set or disable remote access otherwise.
 if [ -v MYSQL_ROOT_PASSWORD ]; then
-mysql $mysql_flags <<EOSQL
-    SET PASSWORD FOR 'root'@'%' = PASSWORD('${MYSQL_ROOT_PASSWORD}');
+  # GRANT will create a user if it doesn't exist and set its password
+  mysql $mysql_flags <<EOSQL
+    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+EOSQL
+else
+  # We do GRANT and DROP USER to emulate a DROP USER IF EXISTS statement
+  # http://bugs.mysql.com/bug.php?id=19166
+  mysql $mysql_flags <<EOSQL
+    GRANT USAGE ON *.* TO 'root'@'%';
+    DROP USER 'root'@'%';
+    FLUSH PRIVILEGES;
 EOSQL
 fi
 

--- a/5.6/run-mysqld.sh
+++ b/5.6/run-mysqld.sh
@@ -31,10 +31,20 @@ mysql $mysql_flags <<EOSQL
   SET PASSWORD FOR '${MYSQL_USER}'@'%' = PASSWORD('${MYSQL_PASSWORD}');
 EOSQL
 
-# The MYSQL_ROOT_PASSWORD is optional
+# The MYSQL_ROOT_PASSWORD is optional, therefore we need to either enable remote
+# access with a password if the variable is set or disable remote access otherwise.
 if [ -v MYSQL_ROOT_PASSWORD ]; then
-mysql $mysql_flags <<EOSQL
-    SET PASSWORD FOR 'root'@'%' = PASSWORD('${MYSQL_ROOT_PASSWORD}');
+  # GRANT will create a user if it doesn't exist and set its password
+  mysql $mysql_flags <<EOSQL
+    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+EOSQL
+else
+  # We do GRANT and DROP USER to emulate a DROP USER IF EXISTS statement
+  # http://bugs.mysql.com/bug.php?id=19166
+  mysql $mysql_flags <<EOSQL
+    GRANT USAGE ON *.* TO 'root'@'%';
+    DROP USER 'root'@'%';
+    FLUSH PRIVILEGES;
 EOSQL
 fi
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ $ docker run -d --name mysql_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass 
 This will create a container named `mysql_database` running MySQL with database
 `db` and user with credentials `user:pass`. Port 3306 will be exposed and mapped
 to the host. If you want your database to be persistent across container executions,
-also add a `-v /host/db/path:/var/lib/mysql/data` argument. This will be the MySQL 
+also add a `-v /host/db/path:/var/lib/mysql/data` argument. This will be the MySQL
 data directory.
 
 If the database directory is not initialized, the entrypoint script will first
@@ -123,6 +123,21 @@ still not require a password.
 
 To disable remote root access, simply unset `MYSQL_ROOT_PASSWORD` and restart
 the container.
+
+
+Changing passwords
+------------------
+
+Since passwords are part of the image configuration, the only supported method
+to change passwords for the database user (`MYSQL_USER`) and root user is by
+changing the environment variables `MYSQL_PASSWORD` and `MYSQL_ROOT_PASSWORD`,
+respectively.
+
+Changing database passwords through SQL statements or any way other than through
+the environment variables aforementioned will cause a mismatch between the
+values stored in the variables and the actual passwords. Whenever a database
+container starts it will reset the passwords to the values stored in the
+environment variables.
 
 
 Test

--- a/README.md
+++ b/README.md
@@ -117,9 +117,12 @@ or if it was already present, `mysqld` is executed and will run as PID 1. You ca
 MySQL root user
 ---------------------------------
 The root user has no password set by default, only allowing local connections.
-You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable when initializing
-your container. This will allow you to login to the root account remotely. Local
-connections will still not require a password.
+You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable. This
+will allow you to login to the root account remotely. Local connections will
+still not require a password.
+
+To disable remote root access, simply unset `MYSQL_ROOT_PASSWORD` and restart
+the container.
 
 
 Test


### PR DESCRIPTION
Part of https://trello.com/c/CsdmW7nJ

Fixes #89.

Missing:
- [x] Test in test/run
- [x] Copy-paste to 5.6 :cry: 
- [x] Verify replication scenario/template
  - [x] After `MYSQL_PASSWORD` changed, I can connect to mysql-master
  - [x] After `MYSQL_PASSWORD` changed, I can connect to mysql-slave (after a sizable amount of seconds)
  - [x] After `MYSQL_ROOT_PASSWORD` changed, I can connect to mysql-master
  - [x] After `MYSQL_ROOT_PASSWORD` changed, I can connect to mysql-slave
- [x] Document set/unset `MYSQL_ROOT_PASSWORD`