### PR TITLE
WIP: Add support for atomic command without systemd unit file

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -21,7 +21,8 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.tags="database,mysql,mysql55"
 
 # Support for atomic run/install/uninstall
-LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --"
+LABEL INSTALL="docker run --rm \"\${IMAGE}\" cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
+      RUN="bash -c 'docker run --name \"\${NAME}\" \"$@\" \"\${IMAGE}\"' --"
 
 EXPOSE 3306
 

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -21,8 +21,7 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.tags="database,mysql,mysql55"
 
 # Support for atomic run/install/uninstall
-LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
-      RUN="docker start \${NAME}"
+LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --"
 
 EXPOSE 3306
 

--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -20,6 +20,10 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mysql55"
 
+# Support for atomic run/install/uninstall
+LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
+      RUN="docker start \${NAME}"
+
 EXPOSE 3306
 
 # This image must forever use UID 27 for mysql user so our volumes are
@@ -34,6 +38,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 
 COPY run-*.sh /usr/local/bin/
 COPY contrib /var/lib/mysql/
+COPY atomic-contrib /usr/share/container-layer/mysql/atomic
 
 # Loosen permission bits to avoid problems running container with arbitrary UID
 RUN chmod -R a+rwx /var/lib/mysql

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -20,8 +20,7 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.tags="database,mysql,mysql55"
 
 # Support for atomic run/install/uninstall
-LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
-      RUN="docker start \${NAME}"
+LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --"
 
 # Labels consumed by Red Hat build service
 LABEL BZComponent="mysql55-docker" \

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -20,7 +20,8 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.tags="database,mysql,mysql55"
 
 # Support for atomic run/install/uninstall
-LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --"
+LABEL INSTALL="docker run --rm \"\${IMAGE}\" cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
+      RUN="bash -c 'docker run --name \"\${NAME}\" \"$@\" \"\${IMAGE}\"' --"
 
 # Labels consumed by Red Hat build service
 LABEL BZComponent="mysql55-docker" \

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -19,6 +19,10 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mysql55"
 
+# Support for atomic run/install/uninstall
+LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
+      RUN="docker start \${NAME}"
+
 # Labels consumed by Red Hat build service
 LABEL BZComponent="mysql55-docker" \
       Name="openshift3/mysql-55-rhel7" \
@@ -41,6 +45,7 @@ RUN yum install -y yum-utils gettext hostname && \
 
 COPY run-*.sh /usr/local/bin/
 COPY contrib /var/lib/mysql/
+COPY atomic-contrib /usr/share/container-layer/mysql/atomic
 
 # Loosen permission bits to avoid problems running container with arbitrary UID
 RUN chmod -R a+rwx /var/lib/mysql

--- a/5.5/atomic-contrib/install.sh
+++ b/5.5/atomic-contrib/install.sh
@@ -5,7 +5,6 @@ MYSQL_GID=27
 
 if ! [ -d "${DATADIR}" ] ; then
   mkdir -p "${DATADIR}"
-  chcon -Rt svirt_sandbox_file_t "${DATADIR}"
   chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
   chmod -R 770 "${DATADIR}"
 fi

--- a/5.5/atomic-contrib/install.sh
+++ b/5.5/atomic-contrib/install.sh
@@ -3,9 +3,11 @@
 MYSQL_UID=27
 MYSQL_GID=27
 
-mkdir -p "${DATADIR}"
-chcon -Rt svirt_sandbox_file_t "${DATADIR}"
-chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
-chmod -R 770 "${DATADIR}"
+if ! [ -d "${DATADIR}" ] ; then
+  mkdir -p "${DATADIR}"
+  chcon -Rt svirt_sandbox_file_t "${DATADIR}"
+  chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
+  chmod -R 770 "${DATADIR}"
+fi
 docker create --restart=on-failure:5 -v "${DATADIR}:/var/lib/mysql/data:Z" --name "${NAME}" "$@" "${IMAGE}"
 

--- a/5.5/atomic-contrib/install.sh
+++ b/5.5/atomic-contrib/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+MYSQL_UID=27
+MYSQL_GID=27
+
+mkdir -p "${DATADIR}"
+chcon -Rt svirt_sandbox_file_t "${DATADIR}"
+chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
+chmod -R 770 "${DATADIR}"
+docker create --restart=on-failure:5 -v "${DATADIR}:/var/lib/mysql/data:Z" --name "${NAME}" "$@" "${IMAGE}"
+

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -20,6 +20,10 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mysql56,rh-mysql56"
 
+# Support for atomic run/install/uninstall
+LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
+      RUN="docker start \${NAME}"
+
 EXPOSE 3306
 
 # This image must forever use UID 27 for mysql user so our volumes are
@@ -34,6 +38,7 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
 
 COPY run-*.sh /usr/local/bin/
 COPY contrib /var/lib/mysql/
+COPY atomic-contrib /usr/share/container-layer/mysql/atomic
 
 # Loosen permission bits to avoid problems running container with arbitrary UID
 RUN chmod -R a+rwx /var/lib/mysql

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -21,7 +21,8 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.tags="database,mysql,mysql56,rh-mysql56"
 
 # Support for atomic run/install/uninstall
-LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --"
+LABEL INSTALL="docker run --rm \"\${IMAGE}\" cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
+      RUN="bash -c 'docker run --name \"\${NAME}\" \"$@\" \"\${IMAGE}\"' --"
 
 EXPOSE 3306
 

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -21,8 +21,7 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.tags="database,mysql,mysql56,rh-mysql56"
 
 # Support for atomic run/install/uninstall
-LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
-      RUN="docker start \${NAME}"
+LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --"
 
 EXPOSE 3306
 

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -20,6 +20,10 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.expose-services="3306:mysql" \
       io.openshift.tags="database,mysql,mysql56,rh-mysql56"
 
+# Support for atomic run/install/uninstall
+LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
+      RUN="docker start \${NAME}"
+
 # Labels consumed by Red Hat build service
 LABEL BZComponent="rh-mysql56-docker" \
       Name="rhscl/rh-mysql56-rhel7" \
@@ -42,6 +46,7 @@ RUN yum install -y yum-utils gettext hostname && \
 
 COPY run-*.sh /usr/local/bin/
 COPY contrib /var/lib/mysql/
+COPY atomic-contrib /usr/share/container-layer/mysql/atomic
 
 # Loosen permission bits to avoid problems running container with arbitrary UID
 RUN chmod -R a+rwx /var/lib/mysql

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -21,7 +21,8 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.tags="database,mysql,mysql56,rh-mysql56"
 
 # Support for atomic run/install/uninstall
-LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --"
+LABEL INSTALL="docker run --rm \"\${IMAGE}\" cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
+      RUN="bash -c 'docker run --name \"\${NAME}\" \"$@\" \"\${IMAGE}\"' --"
 
 # Labels consumed by Red Hat build service
 LABEL BZComponent="rh-mysql56-docker" \

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -21,8 +21,7 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
       io.openshift.tags="database,mysql,mysql56,rh-mysql56"
 
 # Support for atomic run/install/uninstall
-LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --" \
-      RUN="docker start \${NAME}"
+LABEL INSTALL="docker run --rm \${IMAGE} cat /usr/share/container-layer/mysql/atomic/install.sh | bash -s --"
 
 # Labels consumed by Red Hat build service
 LABEL BZComponent="rh-mysql56-docker" \

--- a/5.6/atomic-contrib/install.sh
+++ b/5.6/atomic-contrib/install.sh
@@ -5,7 +5,6 @@ MYSQL_GID=27
 
 if ! [ -d "${DATADIR}" ] ; then
   mkdir -p "${DATADIR}"
-  chcon -Rt svirt_sandbox_file_t "${DATADIR}"
   chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
   chmod -R 770 "${DATADIR}"
 fi

--- a/5.6/atomic-contrib/install.sh
+++ b/5.6/atomic-contrib/install.sh
@@ -3,9 +3,11 @@
 MYSQL_UID=27
 MYSQL_GID=27
 
-mkdir -p "${DATADIR}"
-chcon -Rt svirt_sandbox_file_t "${DATADIR}"
-chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
-chmod -R 770 "${DATADIR}"
+if ! [ -d "${DATADIR}" ] ; then
+  mkdir -p "${DATADIR}"
+  chcon -Rt svirt_sandbox_file_t "${DATADIR}"
+  chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
+  chmod -R 770 "${DATADIR}"
+fi
 docker create --restart=on-failure:5 -v "${DATADIR}:/var/lib/mysql/data:Z" --name "${NAME}" "$@" "${IMAGE}"
 

--- a/5.6/atomic-contrib/install.sh
+++ b/5.6/atomic-contrib/install.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+MYSQL_UID=27
+MYSQL_GID=27
+
+mkdir -p "${DATADIR}"
+chcon -Rt svirt_sandbox_file_t "${DATADIR}"
+chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
+chmod -R 770 "${DATADIR}"
+docker create --restart=on-failure:5 -v "${DATADIR}:/var/lib/mysql/data:Z" --name "${NAME}" "$@" "${IMAGE}"
+

--- a/5.6/atomic-contrib/install.sh
+++ b/5.6/atomic-contrib/install.sh
@@ -3,10 +3,40 @@
 MYSQL_UID=27
 MYSQL_GID=27
 
+ARGS="$@"
+
+# find user option in arguments
+while [ -n "$1" ] ; do
+  case "$1" in
+  -u=*)
+    MYSQL_UID=${1:3}
+  ;;
+  --user=*)
+    MYSQL_UID=${1:7}
+    break
+  ;;
+  -u|--user)
+    MYSQL_UID="$2"
+    break
+  ;;
+  esac
+  shift
+done
+
+# now we can either have X or X:X in MYSQL_UID, so act according ':' presence
+if ! [[ "$MYSQL_UID" == *":"* ]] ; then
+  CHMOD_ARG="$MYSQL_UID:$MYSQL_GID"
+else
+  CHMOD_ARG="$MYSQL_UID"
+fi
+
+
+# init datadir in case it doesn't exist yet
 if ! [ -d "${DATADIR}" ] ; then
   mkdir -p "${DATADIR}"
-  chown -R ${MYSQL_UID}.${MYSQL_GID} "${DATADIR}"
+  chown -R "${CHMOD_ARG}" "${DATADIR}"
   chmod -R 770 "${DATADIR}"
 fi
-docker create --restart=on-failure:5 -v "${DATADIR}:/var/lib/mysql/data:Z" --name "${NAME}" "$@" "${IMAGE}"
+
+docker create --restart=on-failure:5 -v "${DATADIR}:/var/lib/mysql/data:Z" --name "${NAME}" "$ARGS" "${IMAGE}"
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,38 @@ container starts it will reset the passwords to the values stored in the
 environment variables.
 
 
+Usage on Atomic host
+--------------------
+Systems derived from projectatomic.io usually include the `atomic` command that is
+used to run containers besides other things.
+
+To install a new container `mysql1` based on this image on such a system, run:
+
+```
+$ atomic install -n mysqld1 openshift/mysql-55-centos7 -p 3306:3306 -e MYSQL_USER=user -e MYSQL_PASSWORD=secretpass -e MYSQL_DATABASE=db1 
+```
+
+Then to run the container, run:
+
+```
+$ atomic run mysqld1
+```
+
+In order to work with that container, you may either connect to exposed port 3306
+by external client or run this command to connect locally:
+
+```
+$ atomic run mysqld1 bash -c 'mysql'
+```
+
+To stop and uninstall the mysqld1 service, run:
+
+```
+$ atomic stop mysqld1
+$ atomic uninstall mysqld1
+```
+
+
 Test
 ---------------------------------
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,13 @@ To install a new container `mysql1` based on this image on such a system, run:
 $ atomic install -n mysqld1 openshift/mysql-55-centos7 -p 3306:3306 -e MYSQL_USER=user -e MYSQL_PASSWORD=secretpass -e MYSQL_DATABASE=db1 
 ```
 
+This creates directory for data at `/var/lib/mysqld1` on host and will be
+mounted as volume for data in the container. Permissions and SELinux context
+is set to default values if the directory does not exist.
+
+All options after image name (starting with `-p` in the example above) are
+passed to the `docker` as arguments.
+
 Then to run the container, run:
 
 ```


### PR DESCRIPTION
This is reworked PR, similar to https://github.com/openshift/mysql/pull/83 but with these changes:
* no systemd unit file is created, because of https://github.com/projectatomic/atomic/issues/151
* atomic labels are much simpler
* options for docker container (MYSQL_USER and stuff) are not passed by `OPTx` variables, but instead all unknown options from `atomic install` are passed to `docker run` command
* `atomic run <container>` is used to start the created container
* `UNINSTALL` label doesn't have to be used, since only default action is enough