### PR TITLE
Remove MAINTAINER from RHEL images and fix 5.6 image name

### DIFF
--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -1,5 +1,4 @@
 FROM rhel7
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
 
 # MySQL image for OpenShift.
 #

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -10,8 +10,6 @@ FROM rhel7
 #  * $MYSQL_DATABASE - Name of the database to create
 #  * $MYSQL_ROOT_PASSWORD (Optional) - Password for the 'root' MySQL account
 
-MAINTAINER SoftwareCollections.org <sclorg@redhat.com>
-
 ENV MYSQL_VERSION=5.6 \
     HOME=/var/lib/mysql
 
@@ -22,7 +20,7 @@ LABEL io.k8s.description="MySQL is a multi-user, multi-threaded SQL database ser
 
 # Labels consumed by Red Hat build service
 LABEL BZComponent="rh-mysql56-docker" \
-      Name="rhscl/rh-mysql56-rhel7" \
+      Name="rhscl/mysql-56-rhel7" \
       Version="5.6" \
       Release="1" \
       Architecture="x86_64"


### PR DESCRIPTION
Just slight changes:
* we already discussed removing `MAINTAINER` before
* RHSCL image name changed recently to match OpenShift