### PR TITLE
Less loose permission bits for /var/lib/mysql inside container

### DIFF
--- a/5.5/Dockerfile
+++ b/5.5/Dockerfile
@@ -29,14 +29,17 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum -y --setopt=tsflags=nodocs install https://www.softwarecollections.org/en/scls/rhscl/mysql55/epel-7-x86_64/download/rhscl-mysql55-epel-7-x86_64.noarch.rpm && \
     yum -y --setopt=tsflags=nodocs install gettext hostname bind-utils mysql55 && \
     yum clean all && \
-    mkdir -p /var/lib/mysql/data && chown mysql.mysql /var/lib/mysql/data && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 COPY run-*.sh /usr/local/bin/
 COPY contrib /var/lib/mysql/
 
-# Loosen permission bits to avoid problems running container with arbitrary UID
-RUN chmod -R a+rwx /var/lib/mysql
+# Loosen permission bits for group to avoid problems running container with
+# arbitrary UID
+# When only specifying user, group is 0, that's why /var/lib/mysql must have
+# owner mysql.0; that allows to avoid a+rwx for this dir
+RUN chmod -R g+rwx /var/lib/mysql
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -36,14 +36,17 @@ RUN yum install -y yum-utils gettext hostname && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum install -y --setopt=tsflags=nodocs bind-utils mysql55 && \
     yum clean all && \
-    mkdir -p /var/lib/mysql/data && chown mysql.mysql /var/lib/mysql/data && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 COPY run-*.sh /usr/local/bin/
 COPY contrib /var/lib/mysql/
 
-# Loosen permission bits to avoid problems running container with arbitrary UID
-RUN chmod -R a+rwx /var/lib/mysql
+# Loosen permission bits for group to avoid problems running container with
+# arbitrary UID
+# When only specifying user, group is 0, that's why /var/lib/mysql must have
+# owner mysql.0; that allows to avoid a+rwx for this dir
+RUN chmod -R g+rwx /var/lib/mysql
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/5.6/Dockerfile
+++ b/5.6/Dockerfile
@@ -29,14 +29,17 @@ RUN rpmkeys --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7 && \
     yum -y --setopt=tsflags=nodocs install https://www.softwarecollections.org/en/scls/rhscl/rh-mysql56/epel-7-x86_64/download/rhscl-rh-mysql56-epel-7-x86_64.noarch.rpm && \
     yum -y --setopt=tsflags=nodocs install gettext hostname bind-utils rh-mysql56 && \
     yum clean all && \
-    mkdir -p /var/lib/mysql/data && chown mysql.mysql /var/lib/mysql/data && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 COPY run-*.sh /usr/local/bin/
 COPY contrib /var/lib/mysql/
 
-# Loosen permission bits to avoid problems running container with arbitrary UID
-RUN chmod -R a+rwx /var/lib/mysql
+# Loosen permission bits for group to avoid problems running container with
+# arbitrary UID
+# When only specifying user, group is 0, that's why /var/lib/mysql must have
+# owner mysql.0; that allows to avoid a+rwx for this dir
+RUN chmod -R g+rwx /var/lib/mysql
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -37,14 +37,17 @@ RUN yum install -y yum-utils gettext hostname && \
     yum-config-manager --enable rhel-7-server-optional-rpms && \
     yum install -y --setopt=tsflags=nodocs bind-utils rh-mysql56 && \
     yum clean all && \
-    mkdir -p /var/lib/mysql/data && chown mysql.mysql /var/lib/mysql/data && \
+    mkdir -p /var/lib/mysql/data && chown -R mysql.0 /var/lib/mysql && \
     test "$(id mysql)" = "uid=27(mysql) gid=27(mysql) groups=27(mysql)"
 
 COPY run-*.sh /usr/local/bin/
 COPY contrib /var/lib/mysql/
 
-# Loosen permission bits to avoid problems running container with arbitrary UID
-RUN chmod -R a+rwx /var/lib/mysql
+# Loosen permission bits for group to avoid problems running container with
+# arbitrary UID
+# When only specifying user, group is 0, that's why /var/lib/mysql must have
+# owner mysql.0; that allows to avoid a+rwx for this dir
+RUN chmod -R g+rwx /var/lib/mysql
 
 # When bash is started non-interactively, to run a shell script, for example it
 # looks for this variable and source the content of this file. This will enable


### PR DESCRIPTION
As mentioned in https://github.com/openshift/mysql/pull/92#issuecomment-139270899,
using `0777` for `/var/lib/mysql` is not very safe. But we can allow to run the image
as arbitrary user even with `0770` bits, by setting `root` group as owner for `/var/lib/mysql`.

That works because when only specifying user (e.g. `-u 1000`), group 0 is used.