### PR TITLE
Split README.md to usage and general part

### DIFF
--- a/5.5/README.md
+++ b/5.5/README.md
@@ -1,0 +1,92 @@
+MySQL for OpenShift - Docker images
+========================================
+
+This repository contains Dockerfiles for MySQL images for OpenShift.
+Users can choose between RHEL and CentOS based images.
+
+Dockerfile for CentOS is called Dockerfile, Dockerfile for RHEL is called
+Dockerfile.rhel7.
+
+
+Environment variables and volumes
+----------------------------------
+
+The image recognizes the following environment variables that you can set during
+initialization by passing `-e VAR=VALUE` to the Docker run command.
+
+|    Variable name       |    Description                            |
+| :--------------------- | ----------------------------------------- |
+|  `MYSQL_USER`          | User name for MySQL account to be created |
+|  `MYSQL_PASSWORD`      | Password for the user account             |
+|  `MYSQL_DATABASE`      | Database name                             |
+|  `MYSQL_ROOT_PASSWORD` | Password for the root user (optional)     |
+
+The following environment variables influence the MySQL configuration file. They are all optional.
+
+|    Variable name                |    Description                                                    |    Default
+| :------------------------------ | ----------------------------------------------------------------- | -------------------------------
+|  `MYSQL_LOWER_CASE_TABLE_NAMES` | Sets how the table names are stored and compared                  |  0
+|  `MYSQL_MAX_CONNECTIONS`        | The maximum permitted number of simultaneous client connections   |  151
+|  `MYSQL_FT_MIN_WORD_LEN`        | The minimum length of the word to be included in a FULLTEXT index |  4
+|  `MYSQL_FT_MAX_WORD_LEN`        | The maximum length of the word to be included in a FULLTEXT index |  20
+|  `MYSQL_AIO`                    | Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529 |  1
+
+You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
+
+|  Volume mount point      | Description          |
+| :----------------------- | -------------------- |
+|  `/var/lib/mysql/data`   | MySQL data directory |
+
+**Notice: When mouting a directory from the host into the container, ensure that the mounted
+directory has the appropriate permissions and that the owner and group of the directory
+matches the user UID or name which is running inside the container.**
+
+Usage
+---------------------------------
+
+For this, we will assume that you are using the `openshift/mysql-55-centos7` image.
+If you want to set only the mandatory environment variables and not store
+the database in a host directory, execute the following command:
+
+```
+$ docker run -d --name mysql_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 openshift/mysql-55-centos7
+```
+
+This will create a container named `mysql_database` running MySQL with database
+`db` and user with credentials `user:pass`. Port 3306 will be exposed and mapped
+to the host. If you want your database to be persistent across container executions,
+also add a `-v /host/db/path:/var/lib/mysql/data` argument. This will be the MySQL
+data directory.
+
+If the database directory is not initialized, the entrypoint script will first
+run [`mysql_install_db`](https://dev.mysql.com/doc/refman/5.5/en/mysql-install-db.html)
+and setup necessary database users and passwords. After the database is initialized,
+or if it was already present, `mysqld` is executed and will run as PID 1. You can
+ stop the detached container by running `docker stop mysql_database`.
+
+
+MySQL root user
+---------------------------------
+The root user has no password set by default, only allowing local connections.
+You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable. This
+will allow you to login to the root account remotely. Local connections will
+still not require a password.
+
+To disable remote root access, simply unset `MYSQL_ROOT_PASSWORD` and restart
+the container.
+
+
+Changing passwords
+------------------
+
+Since passwords are part of the image configuration, the only supported method
+to change passwords for the database user (`MYSQL_USER`) and root user is by
+changing the environment variables `MYSQL_PASSWORD` and `MYSQL_ROOT_PASSWORD`,
+respectively.
+
+Changing database passwords through SQL statements or any way other than through
+the environment variables aforementioned will cause a mismatch between the
+values stored in the variables and the actual passwords. Whenever a database
+container starts it will reset the passwords to the values stored in the
+environment variables.
+

--- a/5.6/README.md
+++ b/5.6/README.md
@@ -1,0 +1,92 @@
+MySQL for OpenShift - Docker images
+========================================
+
+This repository contains Dockerfiles for MySQL images for OpenShift.
+Users can choose between RHEL and CentOS based images.
+
+Dockerfile for CentOS is called Dockerfile, Dockerfile for RHEL is called
+Dockerfile.rhel7.
+
+
+Environment variables and volumes
+----------------------------------
+
+The image recognizes the following environment variables that you can set during
+initialization by passing `-e VAR=VALUE` to the Docker run command.
+
+|    Variable name       |    Description                            |
+| :--------------------- | ----------------------------------------- |
+|  `MYSQL_USER`          | User name for MySQL account to be created |
+|  `MYSQL_PASSWORD`      | Password for the user account             |
+|  `MYSQL_DATABASE`      | Database name                             |
+|  `MYSQL_ROOT_PASSWORD` | Password for the root user (optional)     |
+
+The following environment variables influence the MySQL configuration file. They are all optional.
+
+|    Variable name                |    Description                                                    |    Default
+| :------------------------------ | ----------------------------------------------------------------- | -------------------------------
+|  `MYSQL_LOWER_CASE_TABLE_NAMES` | Sets how the table names are stored and compared                  |  0
+|  `MYSQL_MAX_CONNECTIONS`        | The maximum permitted number of simultaneous client connections   |  151
+|  `MYSQL_FT_MIN_WORD_LEN`        | The minimum length of the word to be included in a FULLTEXT index |  4
+|  `MYSQL_FT_MAX_WORD_LEN`        | The maximum length of the word to be included in a FULLTEXT index |  20
+|  `MYSQL_AIO`                    | Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529 |  1
+
+You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
+
+|  Volume mount point      | Description          |
+| :----------------------- | -------------------- |
+|  `/var/lib/mysql/data`   | MySQL data directory |
+
+**Notice: When mouting a directory from the host into the container, ensure that the mounted
+directory has the appropriate permissions and that the owner and group of the directory
+matches the user UID or name which is running inside the container.**
+
+Usage
+---------------------------------
+
+For this, we will assume that you are using the `centos/mysql-56-centos7` image.
+If you want to set only the mandatory environment variables and not store
+the database in a host directory, execute the following command:
+
+```
+$ docker run -d --name mysql_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 centos/mysql-56-centos7
+```
+
+This will create a container named `mysql_database` running MySQL with database
+`db` and user with credentials `user:pass`. Port 3306 will be exposed and mapped
+to the host. If you want your database to be persistent across container executions,
+also add a `-v /host/db/path:/var/lib/mysql/data` argument. This will be the MySQL
+data directory.
+
+If the database directory is not initialized, the entrypoint script will first
+run [`mysql_install_db`](https://dev.mysql.com/doc/refman/5.6/en/mysql-install-db.html)
+and setup necessary database users and passwords. After the database is initialized,
+or if it was already present, `mysqld` is executed and will run as PID 1. You can
+ stop the detached container by running `docker stop mysql_database`.
+
+
+MySQL root user
+---------------------------------
+The root user has no password set by default, only allowing local connections.
+You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable. This
+will allow you to login to the root account remotely. Local connections will
+still not require a password.
+
+To disable remote root access, simply unset `MYSQL_ROOT_PASSWORD` and restart
+the container.
+
+
+Changing passwords
+------------------
+
+Since passwords are part of the image configuration, the only supported method
+to change passwords for the database user (`MYSQL_USER`) and root user is by
+changing the environment variables `MYSQL_PASSWORD` and `MYSQL_ROOT_PASSWORD`,
+respectively.
+
+Changing database passwords through SQL statements or any way other than through
+the environment variables aforementioned will cause a mismatch between the
+values stored in the variables and the actual passwords. Whenever a database
+container starts it will reset the passwords to the values stored in the
+environment variables.
+

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Choose either the CentOS7 or RHEL7 based image:
     $ make build TARGET=rhel7 VERSION=5.5
     ```
 
-    *  **CentOS7 based image**
+*  **CentOS7 based image**
 
     This image is available on DockerHub. To download it run:
 
@@ -57,87 +57,14 @@ on all provided versions of MySQL, which must be specified in  `VERSIONS` variab
 This variable must be set to a list with possible versions (subdirectories).**
 
 
-Environment variables and volumes
-----------------------------------
-
-The image recognizes the following environment variables that you can set during
-initialization by passing `-e VAR=VALUE` to the Docker run command.
-
-|    Variable name       |    Description                            |
-| :--------------------- | ----------------------------------------- |
-|  `MYSQL_USER`          | User name for MySQL account to be created |
-|  `MYSQL_PASSWORD`      | Password for the user account             |
-|  `MYSQL_DATABASE`      | Database name                             |
-|  `MYSQL_ROOT_PASSWORD` | Password for the root user (optional)     |
-
-The following environment variables influence the MySQL configuration file. They are all optional.
-
-|    Variable name                |    Description                                                    |    Default
-| :------------------------------ | ----------------------------------------------------------------- | -------------------------------
-|  `MYSQL_LOWER_CASE_TABLE_NAMES` | Sets how the table names are stored and compared                  |  0
-|  `MYSQL_MAX_CONNECTIONS`        | The maximum permitted number of simultaneous client connections   |  151
-|  `MYSQL_FT_MIN_WORD_LEN`        | The minimum length of the word to be included in a FULLTEXT index |  4
-|  `MYSQL_FT_MAX_WORD_LEN`        | The maximum length of the word to be included in a FULLTEXT index |  20
-|  `MYSQL_AIO`                    | Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529 |  1
-
-You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
-
-|  Volume mount point      | Description          |
-| :----------------------- | -------------------- |
-|  `/var/lib/mysql/data`   | MySQL data directory |
-
-**Notice: When mouting a directory from the host into the container, ensure that the mounted
-directory has the appropriate permissions and that the owner and group of the directory
-matches the user UID or name which is running inside the container.**
-
 Usage
 ---------------------------------
 
-For this, we will assume that you are using the `openshift/mysql-55-centos7` image.
-If you want to set only the mandatory environment variables and not store
-the database in a host directory, execute the following command:
+For information about usage of Dockerfile for MySQL 5.6,
+see [usage documentation](5.6/README.md).
 
-```
-$ docker run -d --name mysql_database -e MYSQL_USER=user -e MYSQL_PASSWORD=pass -e MYSQL_DATABASE=db -p 3306:3306 openshift/mysql-55-centos7
-```
-
-This will create a container named `mysql_database` running MySQL with database
-`db` and user with credentials `user:pass`. Port 3306 will be exposed and mapped
-to the host. If you want your database to be persistent across container executions,
-also add a `-v /host/db/path:/var/lib/mysql/data` argument. This will be the MySQL
-data directory.
-
-If the database directory is not initialized, the entrypoint script will first
-run [`mysql_install_db`](https://dev.mysql.com/doc/refman/5.5/en/mysql-install-db.html)
-and setup necessary database users and passwords. After the database is initialized,
-or if it was already present, `mysqld` is executed and will run as PID 1. You can
- stop the detached container by running `docker stop mysql_database`.
-
-
-MySQL root user
----------------------------------
-The root user has no password set by default, only allowing local connections.
-You can set it by setting the `MYSQL_ROOT_PASSWORD` environment variable. This
-will allow you to login to the root account remotely. Local connections will
-still not require a password.
-
-To disable remote root access, simply unset `MYSQL_ROOT_PASSWORD` and restart
-the container.
-
-
-Changing passwords
-------------------
-
-Since passwords are part of the image configuration, the only supported method
-to change passwords for the database user (`MYSQL_USER`) and root user is by
-changing the environment variables `MYSQL_PASSWORD` and `MYSQL_ROOT_PASSWORD`,
-respectively.
-
-Changing database passwords through SQL statements or any way other than through
-the environment variables aforementioned will cause a mismatch between the
-values stored in the variables and the actual passwords. Whenever a database
-container starts it will reset the passwords to the values stored in the
-environment variables.
+For information about usage of Dockerfile for MySQL 5.5,
+see [usage documentation](5.5/README.md).
 
 
 Test


### PR DESCRIPTION
This allows us to maintain two separate variant for every version (default values, image names, links to doc and eventually more, that may be or already is different). As a bonus, we'll have a clean `README.md` with only image-related usage information that can be used in Docker Hub or elsewhere.