### PR TITLE
Use explicit rhel7 version

### DIFF
--- a/5.5/Dockerfile.rhel7
+++ b/5.5/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7
+FROM rhel7.1
 
 # MySQL image for OpenShift.
 #

--- a/5.6/Dockerfile.rhel7
+++ b/5.6/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM rhel7
+FROM rhel7.1
 
 # MySQL image for OpenShift.
 #


### PR DESCRIPTION
Using `rhel7` only doesn't have to correspond with what we expect (latest rhel7), so we need to be more explicit here.