### PR TITLE
Add better logging functionality

### DIFF
--- a/5.5/root/usr/bin/run-mysqld
+++ b/5.5/root/usr/bin/run-mysqld
@@ -3,8 +3,12 @@
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/validate-variables.sh ] && . ${CONTAINER_SCRIPTS_PATH}/validate-variables.sh
+[ -f ${CONTAINER_SCRIPTS_PATH}/validate-variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate-variables.sh
 
+log_volume_info $MYSQL_DATADIR
+
+# Process the MySQL configuration files
+log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 
@@ -14,10 +18,17 @@ else
   start_local_mysql "$@"
 fi
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh ] && . ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh
-[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && . ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+if [ -f ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh ]; then
+  log_info 'Setting passwords ...'
+  source ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh
+fi
+if [ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ]; then
+  log_info 'Sourcing post-init.sh ...'
+  source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+fi
 
 # Restart the MySQL server with public IP bindings
-mysqladmin $admin_flags flush-privileges shutdown
+shutdown_local_mysql
 unset_env_vars
+log_info 'Running final exec -- Only MySQL server logs after this point'
 exec ${MYSQL_PREFIX}/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE "$@" 2>&1

--- a/5.5/root/usr/bin/run-mysqld-master
+++ b/5.5/root/usr/bin/run-mysqld-master
@@ -7,14 +7,17 @@ set -eu
 
 export MYSQL_RUNNING_AS_MASTER=1
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && . ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
-[ -f ${CONTAINER_SCRIPTS_PATH}/validate_variables.sh ] && . ${CONTAINER_SCRIPTS_PATH}/validate_variables.sh
+[ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
+[ -f ${CONTAINER_SCRIPTS_PATH}/validate_variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate_variables.sh
+
+log_volume_info $MYSQL_DATADIR
 
 # The 'server-id' for master needs to be constant
 export MYSQL_SERVER_ID=1
-echo "The 'master' server-id is ${MYSQL_SERVER_ID}"
+log_info "The 'master' server-id is ${MYSQL_SERVER_ID}"
 
 # Process the MySQL configuration files
+log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-master.cnf.template > /etc/my.cnf.d/master.cnf
@@ -25,7 +28,8 @@ else
   start_local_mysql "$@"
 fi
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh ] && . ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh
+log_info 'Setting passwords ...'
+[ -f ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh ] && source ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh
 
 # Setup the 'master' replication on the MySQL server
 # Grant REPLICATION CLIENT so slave can get master status
@@ -35,9 +39,11 @@ mysql $mysql_flags <<EOSQL
   FLUSH PRIVILEGES;
 EOSQL
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && . ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+log_info 'Sourcing post-init.sh ...'
+[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
 
 # Restart the MySQL server with public IP bindings
-mysqladmin $admin_flags flush-privileges shutdown
+shutdown_local_mysql
 unset_env_vars
+log_info 'Running final exec -- Only MySQL server logs after this point'
 exec ${MYSQL_PREFIX}/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE "$@" 2>&1

--- a/5.5/root/usr/bin/run-mysqld-slave
+++ b/5.5/root/usr/bin/run-mysqld-slave
@@ -5,20 +5,24 @@
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
+log_volume_info $MYSQL_DATADIR
+
 # Just run normal server if the data directory is already initialized
 if [ -d "${MYSQL_DATADIR}/mysql" ]; then
+  log_info "Datadir already exists, execing ordinary run script"
   exec /usr/bin/run-mysqld "$@"
 fi
 
 export MYSQL_RUNNING_AS_SLAVE=1
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && . ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
+[ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
 
 # Generate the unique 'server-id' for this master
 export MYSQL_SERVER_ID=$(server_id)
-echo "The 'slave' server-id is ${MYSQL_SERVER_ID}"
+log_info "The 'slave' server-id is ${MYSQL_SERVER_ID}"
 
 # Process the MySQL configuration files
+log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-slave.cnf.template > /etc/my.cnf.d/slave.cnf
@@ -43,10 +47,12 @@ mysql $mysql_flags <<EOSQL
   SET GLOBAL SQL_SLAVE_SKIP_COUNTER = 1; SLAVE START;
 EOSQL
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && . ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+log_info 'Sourcing post-init.sh ...'
+[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
 
 # Restart the MySQL server with public IP bindings
-mysqladmin $admin_flags flush-privileges shutdown
+shutdown_local_mysql
 unset_env_vars
+log_info 'Running final exec -- Only MySQL server logs after this point'
 exec ${MYSQL_PREFIX}/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE \
   --report-host=$(hostname -i) "$@" 2>&1

--- a/5.5/root/usr/share/container-scripts/mysql/helpers.sh
+++ b/5.5/root/usr/share/container-scripts/mysql/helpers.sh
@@ -1,0 +1,24 @@
+function log_info {
+  echo "---> `date +%T`     $@"
+}
+
+function log_and_run {
+  log_info "Running $@"
+  "$@"
+}
+
+function log_volume_info {
+  CONTAINER_DEBUG=${CONTAINER_DEBUG:-}
+  if [[ "${CONTAINER_DEBUG,,}" != "true" ]]; then
+    return
+  fi
+
+  log_info "Volume info for $@:"
+  set +e
+  log_and_run mount
+  while [ $# -gt 0 ]; do
+    log_and_run ls -alZ $1
+    shift
+  done
+  set -e
+}

--- a/5.6/root/usr/bin/run-mysqld
+++ b/5.6/root/usr/bin/run-mysqld
@@ -3,8 +3,10 @@
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/validate-variables.sh ] && . ${CONTAINER_SCRIPTS_PATH}/validate-variables.sh
+[ -f ${CONTAINER_SCRIPTS_PATH}/validate-variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate-variables.sh
 
+# Process the MySQL configuration files
+log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 
@@ -14,10 +16,18 @@ else
   start_local_mysql "$@"
 fi
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh ] && . ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh
-[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && . ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+if [ -f ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh ]; then
+  log_info 'Setting passwords ...'
+  source ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh
+fi
+if [ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ]; then
+  log_info 'Sourcing post-init.sh ...'
+  source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+fi
 
 # Restart the MySQL server with public IP bindings
-mysqladmin $admin_flags flush-privileges shutdown
+shutdown_local_mysql
 unset_env_vars
+log_volume_info $MYSQL_DATADIR
+log_info 'Running final exec -- Only MySQL server logs after this point'
 exec ${MYSQL_PREFIX}/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE "$@" 2>&1

--- a/5.6/root/usr/bin/run-mysqld-master
+++ b/5.6/root/usr/bin/run-mysqld-master
@@ -5,14 +5,15 @@
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && . ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
-[ -f ${CONTAINER_SCRIPTS_PATH}/validate_variables.sh ] && . ${CONTAINER_SCRIPTS_PATH}/validate_variables.sh
+[ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
+[ -f ${CONTAINER_SCRIPTS_PATH}/validate_variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate_variables.sh
 
 # The 'server-id' for master needs to be constant
 export MYSQL_SERVER_ID=1
-echo "The 'master' server-id is ${MYSQL_SERVER_ID}"
+log_info "The 'master' server-id is ${MYSQL_SERVER_ID}"
 
 # Process the MySQL configuration files
+log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-master.cnf.template > /etc/my.cnf.d/master.cnf
@@ -24,7 +25,8 @@ else
   start_local_mysql "$@"
 fi
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh ] && . ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh
+log_info 'Setting passwords ...'
+[ -f ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh ] && source ${CONTAINER_SCRIPTS_PATH}/passwd-change.sh
 
 # Setup the 'master' replication on the MySQL server
 mysql $mysql_flags <<EOSQL
@@ -32,9 +34,12 @@ mysql $mysql_flags <<EOSQL
   FLUSH PRIVILEGES;
 EOSQL
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && . ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+log_info 'Sourcing post-init.sh ...'
+[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
 
 # Restart the MySQL server with public IP bindings
-mysqladmin $admin_flags flush-privileges shutdown
+shutdown_local_mysql
 unset_env_vars
+log_volume_info $MYSQL_DATADIR
+log_info 'Running final exec -- Only MySQL server logs after this point'
 exec ${MYSQL_PREFIX}/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE "$@" 2>&1

--- a/5.6/root/usr/bin/run-mysqld-slave
+++ b/5.6/root/usr/bin/run-mysqld-slave
@@ -12,11 +12,11 @@ fi
 
 export MYSQL_RUNNING_AS_SLAVE=1
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && . ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
+[ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
 
 # Generate the unique 'server-id' for this master
 export MYSQL_SERVER_ID=$(server_id)
-echo "The 'slave' server-id is ${MYSQL_SERVER_ID}"
+log_info "The 'slave' server-id is ${MYSQL_SERVER_ID}"
 
 # Process the MySQL configuration files
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
@@ -33,10 +33,13 @@ mysql $mysql_flags <<EOSQL
   CHANGE MASTER TO MASTER_HOST='${MYSQL_MASTER_SERVICE_NAME}',MASTER_USER='${MYSQL_MASTER_USER}', MASTER_PASSWORD='${MYSQL_MASTER_PASSWORD}', MASTER_AUTO_POSITION = 1;
 EOSQL
 
-[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && . ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+log_info 'Sourcing post-init.sh ...'
+[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
 
 # Restart the MySQL server with public IP bindings
-mysqladmin $admin_flags flush-privileges shutdown
+shutdown_local_mysql
 unset_env_vars
+log_volume_info $MYSQL_DATADIR
+log_info 'Running final exec -- Only MySQL server logs after this point'
 exec ${MYSQL_PREFIX}/libexec/mysqld --defaults-file=$MYSQL_DEFAULTS_FILE \
   --report-host=$(hostname -i) "$@" 2>&1

--- a/5.6/root/usr/share/container-scripts/mysql/common.sh
+++ b/5.6/root/usr/share/container-scripts/mysql/common.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source ${CONTAINER_SCRIPTS_PATH}/helpers.sh
+
 # Data directory where MySQL database files live. The data subdirectory is here
 # because .bashrc and my.cnf both live in /var/lib/mysql/ and we don't want a
 # volume to override it.
@@ -24,6 +26,7 @@ admin_flags="--defaults-file=$MYSQL_DEFAULTS_FILE $mysql_flags"
 
 # Make sure env variables don't propagate to mysqld process.
 function unset_env_vars() {
+  log_info 'Cleaning up environment variables MYSQL_USER, MYSQL_PASSWORD, MYSQL_DATABASE and MYSQL_ROOT_PASSWORD ...'
   unset MYSQL_USER MYSQL_PASSWORD MYSQL_DATABASE MYSQL_ROOT_PASSWORD
 }
 
@@ -33,18 +36,18 @@ function wait_for_mysql() {
 
   while [ true ]; do
     if [ -d "/proc/$pid" ]; then
-      mysqladmin --socket=/tmp/mysql.sock ping &>/dev/null && return 0
+      mysqladmin --socket=/tmp/mysql.sock ping &>/dev/null && log_info "MySQL started successfully" && return 0
     else
       return 1
     fi
-    echo "Waiting for MySQL to start ..."
+    log_info "Waiting for MySQL to start ..."
     sleep 1
   done
 }
 
+# Start local MySQL server with a defaults file
 function start_local_mysql() {
-  # Now start mysqld and add appropriate users.
-  echo 'Starting local mysqld server ...'
+  log_info 'Starting MySQL server with disabled networking ...'
   ${MYSQL_PREFIX}/libexec/mysqld \
     --defaults-file=$MYSQL_DEFAULTS_FILE \
     --skip-networking --socket=/tmp/mysql.sock "$@" &
@@ -52,26 +55,38 @@ function start_local_mysql() {
   wait_for_mysql $mysql_pid
 }
 
+# Shutdown mysql flushing privileges
+function shutdown_local_mysql() {
+  log_info 'Shutting down MySQL ...'
+  mysqladmin $admin_flags flush-privileges shutdown
+}
+
 # Initialize the MySQL database (create user accounts and the initial database)
 function initialize_database() {
-  echo 'Running mysql_install_db ...'
+  log_info 'Initializing database ...'
+  log_info 'Running mysql_install_db ...'  
   # Using --rpm since we need mysql_install_db behaves as in RPM
   mysql_install_db --rpm --datadir=$MYSQL_DATADIR
   start_local_mysql "$@"
 
-  [ -v MYSQL_RUNNING_AS_SLAVE ] && return
+  if [ -v MYSQL_RUNNING_AS_SLAVE ]; then
+    log_info 'Initialization finished'
+    return 0
+  fi
 
   # Do not care what option is compulsory here, just create what is specified
   if [ -v MYSQL_USER ]; then
+    log_info "Creating user specified by MYSQL_USER (${MYSQL_USER}) ..."
 mysql $mysql_flags <<EOSQL
     CREATE USER '${MYSQL_USER}'@'%' IDENTIFIED BY '${MYSQL_PASSWORD}';
 EOSQL
   fi
 
   if [ -v MYSQL_DATABASE ]; then
+    log_info "Creating database ${MYSQL_DATABASE} ..."
     mysqladmin $admin_flags create "${MYSQL_DATABASE}"
-
     if [ -v MYSQL_USER ]; then
+      log_info "Granting privileges to user ${MYSQL_USER} for ${MYSQL_DATABASE} ..."
 mysql $mysql_flags <<EOSQL
       GRANT ALL ON \`${MYSQL_DATABASE}\`.* TO '${MYSQL_USER}'@'%' ;
       FLUSH PRIVILEGES ;
@@ -80,10 +95,12 @@ EOSQL
   fi
 
   if [ -v MYSQL_ROOT_PASSWORD ]; then
+    log_info "Setting password for MySQL root user ..."
 mysql $mysql_flags <<EOSQL
     GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
 EOSQL
   fi
+  log_info 'Initialization finished'
 }
 
 # The 'server_id' number for slave needs to be within 1-4294967295 range.
@@ -98,9 +115,9 @@ function server_id() {
 
 function wait_for_mysql_master() {
   while true; do
-    echo "Waiting for MySQL master (${MYSQL_MASTER_SERVICE_NAME}) to accept connections ..."
+    log_info "Waiting for MySQL master (${MYSQL_MASTER_SERVICE_NAME}) to accept connections ..."
     mysqladmin --host=${MYSQL_MASTER_SERVICE_NAME} --user="${MYSQL_MASTER_USER}" \
-      --password="${MYSQL_MASTER_PASSWORD}" ping &>/dev/null && return 0
+      --password="${MYSQL_MASTER_PASSWORD}" ping &>/dev/null && log_info "MySQL master is ready" && return 0
     sleep 1
   done
 }

--- a/5.6/root/usr/share/container-scripts/mysql/helpers.sh
+++ b/5.6/root/usr/share/container-scripts/mysql/helpers.sh
@@ -1,0 +1,24 @@
+function log_info {
+  echo "---> `date +%T`     $@"
+}
+
+function log_and_run {
+  log_info "Running $@"
+  "$@"
+}
+
+function log_volume_info {
+  CONTAINER_DEBUG=${CONTAINER_DEBUG:-}
+  if [[ "${CONTAINER_DEBUG,,}" != "true" ]]; then
+    return
+  fi
+
+  log_info "Volume info for $@:"
+  set +e
+  log_and_run mount
+  while [ $# -gt 0 ]; do
+    log_and_run ls -alZ $1
+    shift
+  done
+  set -e
+}


### PR DESCRIPTION
This is my first stab at #112. I'd like to get feedback before adopting this for 5.6 and other DB images. For now I'm only adding one logging function (first point of #112), but will add debugging variable shortly.

CC: @bparees @rhcarvalho @hhorak @praiskup @eliskasl @mfojtik 

Sample run:
```
[vagrant@openshiftdev perl_example]$ docker run -e MYSQL_ROOT_PASSWORD=pass -ti --rm fd3a72c89014
CONTAINER[3f610f6821d5] 11:07:28     Processing MySQL configuration files ...
CONTAINER[3f610f6821d5] 11:07:28     Initializing database ...
CONTAINER[3f610f6821d5] 11:07:28     Running mysql_install_db ...
160201 11:07:28 [Note] /opt/rh/mysql55/root/usr/libexec/mysqld (mysqld 5.5.45) starting as process 40 ...
160201 11:07:28 [Note] /opt/rh/mysql55/root/usr/libexec/mysqld (mysqld 5.5.45) starting as process 47 ...

PLEASE REMEMBER TO SET A PASSWORD FOR THE MySQL root USER !
To do so, start the server, then issue the following commands:

scl enable mysql55 -- /opt/rh/mysql55/root/usr/bin/mysqladmin -u root password 'new-password'
scl enable mysql55 -- /opt/rh/mysql55/root/usr/bin/mysqladmin -u root -h 3f610f6821d5 password 'new-password'

Alternatively you can run:
scl enable mysql55 -- /opt/rh/mysql55/root/usr/bin/mysql_secure_installation

which will also give you the option of removing the test
databases and anonymous user created by default.  This is
strongly recommended for production servers.

See the manual for more instructions.

Please report any problems at http://bugs.mysql.com/

CONTAINER[3f610f6821d5] 11:07:28     Starting MySQL server with disabled networking ...
160201 11:07:28 [Note] /opt/rh/mysql55/root/usr/libexec/mysqld (mysqld 5.5.45) starting as process 53 ...
CONTAINER[3f610f6821d5] 11:07:28     Waiting for MySQL to start ...
160201 11:07:28 [Note] Plugin 'FEDERATED' is disabled.
160201 11:07:28 InnoDB: The InnoDB memory heap is disabled
160201 11:07:28 InnoDB: Mutexes and rw_locks use GCC atomic builtins
160201 11:07:28 InnoDB: Compressed tables use zlib 1.2.7
160201 11:07:28 InnoDB: Using Linux native AIO
160201 11:07:28 InnoDB: Initializing buffer pool, size = 128.0M
160201 11:07:28 InnoDB: Completed initialization of buffer pool
InnoDB: The first specified data file ./ibdata1 did not exist:
InnoDB: a new database to be created!
160201 11:07:28  InnoDB: Setting file ./ibdata1 size to 10 MB
InnoDB: Database physically writes the file full: wait...
160201 11:07:28  InnoDB: Log file ./ib_logfile0 did not exist: new to be created
InnoDB: Setting log file ./ib_logfile0 size to 5 MB
InnoDB: Database physically writes the file full: wait...
160201 11:07:28  InnoDB: Log file ./ib_logfile1 did not exist: new to be created
InnoDB: Setting log file ./ib_logfile1 size to 5 MB
InnoDB: Database physically writes the file full: wait...
InnoDB: Doublewrite buffer not found: creating new
InnoDB: Doublewrite buffer created
InnoDB: 127 rollback segment(s) active.
InnoDB: Creating foreign key constraint system tables
InnoDB: Foreign key constraint system tables created
160201 11:07:28  InnoDB: Waiting for the background threads to start
CONTAINER[3f610f6821d5] 11:07:29     Waiting for MySQL to start ...
160201 11:07:29 InnoDB: 5.5.45 started; log sequence number 0
160201 11:07:29 [Warning] 'user' entry 'root@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:29 [Warning] 'user' entry '@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:29 [Warning] 'proxies_priv' entry '@ root@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:29 [Note] Event Scheduler: Loaded 0 events
160201 11:07:29 [Note] /opt/rh/mysql55/root/usr/libexec/mysqld: ready for connections.
Version: '5.5.45'  socket: '/tmp/mysql.sock'  port: 0  MySQL Community Server (GPL)
CONTAINER[3f610f6821d5] 11:07:30     MySQL started successfully
CONTAINER[3f610f6821d5] 11:07:30     Dropping the "test" database ...
Database "test" dropped
CONTAINER[3f610f6821d5] 11:07:30     Setting password for root ...
CONTAINER[3f610f6821d5] 11:07:30     Initialization finished
CONTAINER[3f610f6821d5] 11:07:30     Setting passwords ...
CONTAINER[3f610f6821d5] 11:07:30     Sourcing post-init.sh ...
CONTAINER[3f610f6821d5] 11:07:30     Shutting down MySQL ...
160201 11:07:30 [Warning] 'user' entry 'root@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:30 [Warning] 'user' entry '@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:30 [Warning] 'proxies_priv' entry '@ root@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:30 [Note] /opt/rh/mysql55/root/usr/libexec/mysqld: Normal shutdown

160201 11:07:30 [Note] Event Scheduler: Purging the queue. 0 events
160201 11:07:30  InnoDB: Starting shutdown...
160201 11:07:32  InnoDB: Shutdown completed; log sequence number 1595675
160201 11:07:32 [Note] /opt/rh/mysql55/root/usr/libexec/mysqld: Shutdown complete

CONTAINER[3f610f6821d5] 11:07:32     Cleaning up environment variables ...
CONTAINER[3f610f6821d5] 11:07:32     Running final exec -- Only MySQL server logs after this point
160201 11:07:32 [Note] /opt/rh/mysql55/root/usr/libexec/mysqld (mysqld 5.5.45) starting as process 1 ...
160201 11:07:32 [Note] Plugin 'FEDERATED' is disabled.
160201 11:07:32 InnoDB: The InnoDB memory heap is disabled
160201 11:07:32 InnoDB: Mutexes and rw_locks use GCC atomic builtins
160201 11:07:32 InnoDB: Compressed tables use zlib 1.2.7
160201 11:07:32 InnoDB: Using Linux native AIO
160201 11:07:32 InnoDB: Initializing buffer pool, size = 128.0M
160201 11:07:32 InnoDB: Completed initialization of buffer pool
160201 11:07:32 InnoDB: highest supported file format is Barracuda.
160201 11:07:32  InnoDB: Waiting for the background threads to start
160201 11:07:33 InnoDB: 5.5.45 started; log sequence number 1595675
160201 11:07:33 [Note] Server hostname (bind-address): '0.0.0.0'; port: 3306
160201 11:07:33 [Note]   - '0.0.0.0' resolves to '0.0.0.0';
160201 11:07:33 [Note] Server socket created on IP: '0.0.0.0'.
160201 11:07:33 [Warning] 'user' entry 'root@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:33 [Warning] 'user' entry '@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:33 [Warning] 'proxies_priv' entry '@ root@3f610f6821d5' ignored in --skip-name-resolve mode.
160201 11:07:33 [Note] Event Scheduler: Loaded 0 events
160201 11:07:33 [Note] /opt/rh/mysql55/root/usr/libexec/mysqld: ready for connections.
Version: '5.5.45'  socket: '/var/lib/mysql/mysql.sock'  port: 3306  MySQL Community Server (GPL)
```