### PR TITLE
Grant the grant privilege to the root user

### DIFF
--- a/5.5/root/usr/share/container-scripts/mysql/common.sh
+++ b/5.5/root/usr/share/container-scripts/mysql/common.sh
@@ -115,7 +115,7 @@ EOSQL
   if [ -v MYSQL_ROOT_PASSWORD ]; then
     log_info "Setting password for MySQL root user ..."
 mysql $mysql_flags <<EOSQL
-    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;
 EOSQL
   fi
   log_info 'Initialization finished'

--- a/5.5/root/usr/share/container-scripts/mysql/passwd-change.sh
+++ b/5.5/root/usr/share/container-scripts/mysql/passwd-change.sh
@@ -11,7 +11,7 @@ fi
 if [ -v MYSQL_ROOT_PASSWORD ]; then
   # GRANT will create a user if it doesn't exist and set its password
   mysql $mysql_flags <<EOSQL
-    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;
 EOSQL
 else
   # We do GRANT and DROP USER to emulate a DROP USER IF EXISTS statement

--- a/5.6/root/usr/share/container-scripts/mysql/common.sh
+++ b/5.6/root/usr/share/container-scripts/mysql/common.sh
@@ -97,7 +97,7 @@ EOSQL
   if [ -v MYSQL_ROOT_PASSWORD ]; then
     log_info "Setting password for MySQL root user ..."
 mysql $mysql_flags <<EOSQL
-    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;
 EOSQL
   fi
   log_info 'Initialization finished'

--- a/5.6/root/usr/share/container-scripts/mysql/passwd-change.sh
+++ b/5.6/root/usr/share/container-scripts/mysql/passwd-change.sh
@@ -11,7 +11,7 @@ fi
 if [ -v MYSQL_ROOT_PASSWORD ]; then
   # GRANT will create a user if it doesn't exist and set its password
   mysql $mysql_flags <<EOSQL
-    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}';
+    GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' WITH GRANT OPTION;
 EOSQL
 else
   # We do GRANT and DROP USER to emulate a DROP USER IF EXISTS statement


### PR DESCRIPTION
Should enable root to set privileges for databases to other users. Root already has this privilege, but only by default when connecting from localhost. After this fix, it should work even when connecting remotely.

Fixes #125.