### PR TITLE
README.md: add example for pulling 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Choose either the CentOS7 or RHEL7 based image:
     $ docker pull openshift/mysql-55-centos7
     ```
 
+    or
+
+    ```
+    $ docker pull centos/mysql-56-centos7
+    ```
+
     To build a MySQL image from scratch run:
 
     ```


### PR DESCRIPTION
Emphasize that images for 5.5 and 5.6 reside in a different namespaces.

PTAL @bparees @mfojtik