### PR TITLE
[WIP] Porting MySQL tuning from V2

### DIFF
--- a/5.5/README.md
+++ b/5.5/README.md
@@ -27,9 +27,17 @@ The following environment variables influence the MySQL configuration file. They
 | :------------------------------ | ----------------------------------------------------------------- | -------------------------------
 |  `MYSQL_LOWER_CASE_TABLE_NAMES` | Sets how the table names are stored and compared                  |  0
 |  `MYSQL_MAX_CONNECTIONS`        | The maximum permitted number of simultaneous client connections   |  151
+|  `MYSQL_MAX_ALLOWED_PACKET`     | The maximum size of one packet or any generated/intermediate string | 200M
 |  `MYSQL_FT_MIN_WORD_LEN`        | The minimum length of the word to be included in a FULLTEXT index |  4
 |  `MYSQL_FT_MAX_WORD_LEN`        | The maximum length of the word to be included in a FULLTEXT index |  20
 |  `MYSQL_AIO`                    | Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529 |  1
+|  `MYSQL_TABLE_OPEN_CACHE`       | The number of open tables for all threads                         |  400
+|  `MYSQL_KEY_BUFFER_SIZE`        | The size of the buffer used for index blocks                      |  32M (or 10% of available memory)
+|  `MYSQL_SORT_BUFFER_SIZE`       | The size of the buffer used for sorting                           |  256K
+|  `MYSQL_READ_BUFFER_SIZE`       | The size of the buffer used for a sequential scan                 |  8M (or 5% of available memory)
+|  `MYSQL_INNODB_BUFFER_POOL_SIZE`| The size of the buffer pool where InnoDB caches table and index data |  32M (or 50% of available memory)
+|  `MYSQL_INNODB_LOG_FILE_SIZE`   | The size of each log file in a log group                          |  8M (or 15% of available available)
+|  `MYSQL_INNODB_LOG_BUFFER_SIZE` | The size of the buffer that InnoDB uses to write to the log files on disk | 8M (or 15% of available memory)
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
@@ -63,6 +71,22 @@ run [`mysql_install_db`](https://dev.mysql.com/doc/refman/en/mysql-install-db.ht
 and setup necessary database users and passwords. After the database is initialized,
 or if it was already present, `mysqld` is executed and will run as PID 1. You can
  stop the detached container by running `docker stop mysql_database`.
+
+
+MySQL auto-tuning
+-----------------
+
+When the MySQL image is run with the `--memory` parameter set and you didn't
+specify value for some parameters, their values will be automatically
+calculated based on the available memory.
+
+| Variable name                   | Configuration parameter   | Relative value
+| :-------------------------------| ------------------------- | --------------
+| `MYSQL_KEY_BUFFER_SIZE`         | `key_buffer_size`         | 10%
+| `MYSQL_READ_BUFFER_SIZE`        | `read_buffer_size`        | 5%
+| `MYSQL_INNODB_BUFFER_POOL_SIZE` | `innodb_buffer_pool_size` | 50%
+| `MYSQL_INNODB_LOG_FILE_SIZE`    | `innodb_log_file_size`    | 15%
+| `MYSQL_INNODB_LOG_BUFFER_SIZE`  | `innodb_log_buffer_size`  | 15%
 
 
 MySQL root user

--- a/5.5/root/usr/bin/cgroup-limits
+++ b/5.5/root/usr/bin/cgroup-limits
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+"""
+Script for parsing cgroup information
+
+This script will read some limits from the cgroup system and parse
+them, printing out "VARIABLE=VALUE" on each line for every limit that is
+successfully read. Output of this script can be directly fed into
+bash's export command. Recommended usage from a bash script:
+
+    set -o errexit
+    export_vars=$(cgroup-limits) ; export $export_vars
+
+Variables currently supported:
+    MAX_MEMORY_LIMIT_IN_BYTES
+        Maximum possible limit MEMORY_LIMIT_IN_BYTES can have. This is
+        currently constant value of 9223372036854775807.
+    MEMORY_LIMIT_IN_BYTES
+        Maximum amount of user memory in bytes. If this value is set
+        to the same value as MAX_MEMORY_LIMIT_IN_BYTES, it means that
+        there is no limit set. The value is taken from
+        /sys/fs/cgroup/memory/memory.limit_in_bytes
+    NUMBER_OF_CORES
+        Number of detected CPU cores that can be used. This value is
+        calculated from /sys/fs/cgroup/cpuset/cpuset.cpus
+    NO_MEMORY_LIMIT
+        Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
+        can act as if no memory limit was set. Undefined otherwise.
+"""
+
+from __future__ import print_function
+import sys
+
+
+def _read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except IOError:
+        return None
+
+
+def get_memory_limit():
+    """
+    Read memory limit, in bytes.
+    """
+
+    limit = _read_file('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+    if limit is None or not limit.isdigit():
+        print("Warning: Can't detect memory limit from cgroups",
+              file=sys.stderr)
+        return None
+    return int(limit)
+
+
+def get_number_of_cores():
+    """
+    Read number of CPU cores.
+    """
+
+    core_count = 0
+
+    line = _read_file('/sys/fs/cgroup/cpuset/cpuset.cpus')
+    if line is None:
+        print("Warning: Can't detect number of CPU cores from cgroups",
+              file=sys.stderr)
+        return None
+
+    for group in line.split(','):
+        core_ids = list(map(int, group.split('-')))
+        if len(core_ids) == 2:
+            core_count += core_ids[1] - core_ids[0] + 1
+        else:
+            core_count += 1
+
+    return core_count
+
+
+if __name__ == "__main__":
+    env_vars = {
+        "MAX_MEMORY_LIMIT_IN_BYTES": 9223372036854775807,
+        "MEMORY_LIMIT_IN_BYTES": get_memory_limit(),
+        "NUMBER_OF_CORES": get_number_of_cores()
+    }
+
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+
+    if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
+        env_vars["NO_MEMORY_LIMIT"] = "true"
+
+    for key, value in env_vars.items():
+        print("{0}={1}".format(key, value))

--- a/5.5/root/usr/bin/run-mysqld
+++ b/5.5/root/usr/bin/run-mysqld
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
@@ -11,6 +12,7 @@ log_volume_info $MYSQL_DATADIR
 log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
+envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
 
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
   initialize_database "$@"

--- a/5.5/root/usr/bin/run-mysqld-master
+++ b/5.5/root/usr/bin/run-mysqld-master
@@ -2,6 +2,7 @@
 #
 # This is an entrypoint that runs the MySQL server in the 'master' mode.
 #
+export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
@@ -21,6 +22,7 @@ log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-master.cnf.template > /etc/my.cnf.d/master.cnf
+envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
 
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
   initialize_database "$@"

--- a/5.5/root/usr/bin/run-mysqld-slave
+++ b/5.5/root/usr/bin/run-mysqld-slave
@@ -2,6 +2,7 @@
 #
 # This is an entrypoint that runs the MySQL server in the 'slave' mode.
 #
+export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
@@ -26,6 +27,7 @@ log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-slave.cnf.template > /etc/my.cnf.d/slave.cnf
+envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
 
 # Initialize MySQL database and wait for the MySQL master to accept
 # connections.

--- a/5.5/root/usr/share/container-scripts/mysql/common.sh
+++ b/5.5/root/usr/share/container-scripts/mysql/common.sh
@@ -14,6 +14,28 @@ export MYSQL_MAX_CONNECTIONS=${MYSQL_MAX_CONNECTIONS:-151}
 export MYSQL_FT_MIN_WORD_LEN=${MYSQL_FT_MIN_WORD_LEN:-4}
 export MYSQL_FT_MAX_WORD_LEN=${MYSQL_FT_MAX_WORD_LEN:-20}
 export MYSQL_AIO=${MYSQL_AIO:-1}
+export MYSQL_MAX_ALLOWED_PACKET=${MYSQL_MAX_ALLOWED_PACKET:-200M}
+export MYSQL_TABLE_OPEN_CACHE=${MYSQL_TABLE_OPEN_CACHE:-400}
+export MYSQL_SORT_BUFFER_SIZE=${MYSQL_SORT_BUFFER_SIZE:-256K}
+
+if [ -n "${NO_MEMORY_LIMIT:-}" -o -z "${MEMORY_LIMIT_IN_BYTES:-}" ]; then
+  key_buffer_size='32M'
+  read_buffer_size='8M'
+  innodb_buffer_pool_size='32M'
+  innodb_log_file_size='8M'
+  innodb_log_buffer_size='8M'
+else
+  key_buffer_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.1))")M"
+  read_buffer_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.05))")M"
+  innodb_buffer_pool_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.5))")M"
+  innodb_log_file_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.15))")M"
+  innodb_log_buffer_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.15))")M"
+fi
+export MYSQL_KEY_BUFFER_SIZE=${MYSQL_KEY_BUFFER_SIZE:-$key_buffer_size}
+export MYSQL_READ_BUFFER_SIZE=${MYSQL_READ_BUFFER_SIZE:-$read_buffer_size}
+export MYSQL_INNODB_BUFFER_POOL_SIZE=${MYSQL_INNODB_BUFFER_POOL_SIZE:-$innodb_buffer_pool_size}
+export MYSQL_INNODB_LOG_FILE_SIZE=${MYSQL_INNODB_LOG_FILE_SIZE:-$innodb_log_file_size}
+export MYSQL_INNODB_LOG_BUFFER_SIZE=${MYSQL_INNODB_LOG_BUFFER_SIZE:-$innodb_log_buffer_size}
 
 # Be paranoid and stricter than we should be.
 # https://dev.mysql.com/doc/refman/en/identifiers.html

--- a/5.5/root/usr/share/container-scripts/mysql/my-paas.cnf.template
+++ b/5.5/root/usr/share/container-scripts/mysql/my-paas.cnf.template
@@ -9,12 +9,18 @@ lower_case_table_names = ${MYSQL_LOWER_CASE_TABLE_NAMES}
 # The maximum permitted number of simultaneous client connections. Default: 151
 max_connections = ${MYSQL_MAX_CONNECTIONS}
 
-# The minimum length of the word to be included in a FULLTEXT index. Default: 4
+# The minimum/maximum lengths of the word to be included in a FULLTEXT index. Default: 4/20
 ft_min_word_len = ${MYSQL_FT_MIN_WORD_LEN}
-
-# The maximum length of the word to be included in a FULLTEXT index. Default: 20
 ft_max_word_len = ${MYSQL_FT_MAX_WORD_LEN}
 
 # In case the native AIO is broken. Default: 1
 # See http://help.directadmin.com/item.php?id=529
 innodb_use_native_aio = ${MYSQL_AIO}
+
+[myisamchk]
+# The minimum/maximum lengths of the word to be included in a FULLTEXT index. Default: 4/20
+#
+# To ensure that myisamchk and the server use the same values for full-text
+# parameters, we placed them in both sections.
+ft_min_word_len = ${MYSQL_FT_MIN_WORD_LEN}
+ft_max_word_len = ${MYSQL_FT_MAX_WORD_LEN}

--- a/5.5/root/usr/share/container-scripts/mysql/my-tuning.cnf.template
+++ b/5.5/root/usr/share/container-scripts/mysql/my-tuning.cnf.template
@@ -1,0 +1,28 @@
+[mysqld]
+key_buffer_size = ${MYSQL_KEY_BUFFER_SIZE}
+max_allowed_packet = ${MYSQL_MAX_ALLOWED_PACKET}
+table_open_cache = ${MYSQL_TABLE_OPEN_CACHE}
+sort_buffer_size = ${MYSQL_SORT_BUFFER_SIZE}
+read_buffer_size = ${MYSQL_READ_BUFFER_SIZE}
+read_rnd_buffer_size = 256K
+net_buffer_length = 2K
+thread_stack = 256K
+myisam_sort_buffer_size = 2M
+
+# It is recommended that innodb_buffer_pool_size is configured to 50 to 75 percent of system memory.
+innodb_buffer_pool_size = ${MYSQL_INNODB_BUFFER_POOL_SIZE}
+innodb_additional_mem_pool_size = 2M
+# Set .._log_file_size to 25 % of buffer pool size
+innodb_log_file_size = ${MYSQL_INNODB_LOG_FILE_SIZE}
+innodb_log_buffer_size = ${MYSQL_INNODB_LOG_BUFFER_SIZE}
+
+[mysqldump]
+quick
+max_allowed_packet = 16M
+
+[mysql]
+no-auto-rehash
+
+[myisamchk]
+key_buffer_size = 8M
+sort_buffer_size = 8M

--- a/5.5/root/usr/share/container-scripts/mysql/validate-variables.sh
+++ b/5.5/root/usr/share/container-scripts/mysql/validate-variables.sh
@@ -13,6 +13,14 @@ function usage() {
   echo "  MYSQL_FT_MIN_WORD_LEN (default: 4)"
   echo "  MYSQL_FT_MAX_WORD_LEN (default: 20)"
   echo "  MYSQL_AIO (default: 1)"
+  echo "  MYSQL_KEY_BUFFER_SIZE (default: 32M or 10% of available memory)"
+  echo "  MYSQL_MAX_ALLOWED_PACKET (default: 200M)"
+  echo "  MYSQL_TABLE_OPEN_CACHE (default: 400)"
+  echo "  MYSQL_SORT_BUFFER_SIZE (default: 256K)"
+  echo "  MYSQL_READ_BUFFER_SIZE (default: 8M or 5% of available memory)"
+  echo "  MYSQL_INNODB_BUFFER_POOL_SIZE (default: 32M or 50% of available memory)"
+  echo "  MYSQL_INNODB_LOG_FILE_SIZE (default: 8M or 15% of available memory)"
+  echo "  MYSQL_INNODB_LOG_BUFFER_SIZE (default: 8M or 15% of available memory)"
   exit 1
 }
 

--- a/5.5/test/run
+++ b/5.5/test/run
@@ -128,15 +128,15 @@ function run_replication_test() {
   # Run the MySQL master
   docker run $cluster_args -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
     -e MYSQL_ROOT_PASSWORD=root \
-    -d --cidfile ${CIDFILE_DIR}/master.cid $IMAGE_NAME mysqld-master \
-    --innodb_buffer_pool_size=5242880
+    -e MYSQL_INNODB_BUFFER_POOL_SIZE=5M \
+    -d --cidfile ${CIDFILE_DIR}/master.cid $IMAGE_NAME mysqld-master
   local master_ip
   master_ip=$(get_container_ip master.cid)
 
   # Run the MySQL slave
   docker run $cluster_args -e MYSQL_MASTER_SERVICE_NAME=${master_ip} \
-    -d --cidfile ${CIDFILE_DIR}/slave.cid $IMAGE_NAME mysqld-slave \
-    --innodb_buffer_pool_size=5242880
+    -e MYSQL_INNODB_BUFFER_POOL_SIZE=5M \
+    -d --cidfile ${CIDFILE_DIR}/slave.cid $IMAGE_NAME mysqld-slave
   local slave_ip
   slave_ip=$(get_container_ip slave.cid)
 
@@ -225,12 +225,13 @@ function run_container_creation_tests() {
 }
 
 function test_config_option() {
-  local configuration="$1"
-  local option_name="$2"
-  local option_value="$3"
+  local container_name="$1"
+  local configuration="$2"
+  local option_name="$3"
+  local option_value="$4"
 
   if ! echo "$configuration" | grep -qx "$option_name[[:space:]]*=[[:space:]]*$option_value"; then
-    local configs="$(docker exec -t config_test bash -c 'set +f; shopt -s nullglob; echo /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/* | paste -s')"
+    local configs="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; echo /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/* | paste -s')"
     echo >&2 "FAIL: option '$option_name' should have value '$option_value', but it wasn't found in any of the configuration files ($configs):"
     echo >&2
     echo >&2 "$configuration"
@@ -244,9 +245,11 @@ function test_config_option() {
 function run_configuration_tests() {
   echo "  Testing image configuration settings"
 
+  local container_name=config_test
+
   create_container \
-    config_test \
-    --name config_test \
+    "$container_name" \
+    --name "$container_name" \
     --env MYSQL_USER=config_test_user \
     --env MYSQL_PASSWORD=config_test \
     --env MYSQL_DATABASE=db \
@@ -254,22 +257,63 @@ function run_configuration_tests() {
     --env MYSQL_MAX_CONNECTIONS=1337 \
     --env MYSQL_FT_MIN_WORD_LEN=8 \
     --env MYSQL_FT_MAX_WORD_LEN=15 \
+    --env MYSQL_MAX_ALLOWED_PACKET=10M \
+    --env MYSQL_TABLE_OPEN_CACHE=100 \
+    --env MYSQL_SORT_BUFFER_SIZE=256K \
+    --env MYSQL_KEY_BUFFER_SIZE=16M \
+    --env MYSQL_READ_BUFFER_SIZE=16M \
+    --env MYSQL_INNODB_BUFFER_POOL_SIZE=16M \
+    --env MYSQL_INNODB_LOG_FILE_SIZE=4M \
+    --env MYSQL_INNODB_LOG_BUFFER_SIZE=4M \
+    --env WORKAROUND_DOCKER_BUG_14203=
     #
 
-  test_connection config_test config_test_user config_test
+  test_connection "$container_name" config_test_user config_test
 
   # TODO: this check is far from perfect and could be improved:
   # - we should look for an option in the desired config, not in all of them
   # - we should respect section of the config (now we have duplicated options from a different sections)
   local configuration
-  configuration="$(docker exec -t config_test bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
+  configuration="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
 
-  test_config_option "$configuration" lower_case_table_names 1
-  test_config_option "$configuration" max_connections 1337
-  test_config_option "$configuration" ft_min_word_len 8
-  test_config_option "$configuration" ft_max_word_len 15
+  test_config_option "$container_name" "$configuration" lower_case_table_names 1
+  test_config_option "$container_name" "$configuration" max_connections 1337
+  test_config_option "$container_name" "$configuration" ft_min_word_len 8
+  test_config_option "$container_name" "$configuration" ft_max_word_len 15
+  test_config_option "$container_name" "$configuration" max_allowed_packet 10M
+  test_config_option "$container_name" "$configuration" table_open_cache 100
+  test_config_option "$container_name" "$configuration" sort_buffer_size 256K
+  test_config_option "$container_name" "$configuration" key_buffer_size 16M
+  test_config_option "$container_name" "$configuration" read_buffer_size 16M
+  test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 16M
+  test_config_option "$container_name" "$configuration" innodb_log_file_size 4M
+  test_config_option "$container_name" "$configuration" innodb_log_buffer_size 4M
 
-  docker stop config_test >/dev/null
+  docker stop "$container_name" >/dev/null
+
+  echo "  Success!"
+  echo "  Testing image auto-calculated configuration settings"
+
+  container_name=dynamic_config_test
+
+  DOCKER_ARGS='--memory=256m' create_container \
+    "$container_name" \
+    --name "$container_name" \
+    --env MYSQL_USER=config_test_user \
+    --env MYSQL_PASSWORD=config_test \
+    --env MYSQL_DATABASE=db
+
+  test_connection "$container_name" config_test_user config_test
+
+  configuration="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
+
+  test_config_option "$container_name" "$configuration" key_buffer_size 25M
+  test_config_option "$container_name" "$configuration" read_buffer_size 12M
+  test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 128M
+  test_config_option "$container_name" "$configuration" innodb_log_file_size 38M
+  test_config_option "$container_name" "$configuration" innodb_log_buffer_size 38M
+
+  docker stop "$container_name" >/dev/null
 
   echo "  Success!"
 }

--- a/5.6/README.md
+++ b/5.6/README.md
@@ -27,9 +27,17 @@ The following environment variables influence the MySQL configuration file. They
 | :------------------------------ | ----------------------------------------------------------------- | -------------------------------
 |  `MYSQL_LOWER_CASE_TABLE_NAMES` | Sets how the table names are stored and compared                  |  0
 |  `MYSQL_MAX_CONNECTIONS`        | The maximum permitted number of simultaneous client connections   |  151
+|  `MYSQL_MAX_ALLOWED_PACKET`     | The maximum size of one packet or any generated/intermediate string | 200M
 |  `MYSQL_FT_MIN_WORD_LEN`        | The minimum length of the word to be included in a FULLTEXT index |  4
 |  `MYSQL_FT_MAX_WORD_LEN`        | The maximum length of the word to be included in a FULLTEXT index |  20
 |  `MYSQL_AIO`                    | Controls the `innodb_use_native_aio` setting value in case the native AIO is broken. See http://help.directadmin.com/item.php?id=529 |  1
+|  `MYSQL_TABLE_OPEN_CACHE`       | The number of open tables for all threads                         |  400
+|  `MYSQL_KEY_BUFFER_SIZE`        | The size of the buffer used for index blocks                      |  32M (or 10% of available memory)
+|  `MYSQL_SORT_BUFFER_SIZE`       | The size of the buffer used for sorting                           |  256K
+|  `MYSQL_READ_BUFFER_SIZE`       | The size of the buffer used for a sequential scan                 |  8M (or 5% of available memory)
+|  `MYSQL_INNODB_BUFFER_POOL_SIZE`| The size of the buffer pool where InnoDB caches table and index data |  32M (or 50% of available memory)
+|  `MYSQL_INNODB_LOG_FILE_SIZE`   | The size of each log file in a log group                          |  8M (or 15% of available available)
+|  `MYSQL_INNODB_LOG_BUFFER_SIZE` | The size of the buffer that InnoDB uses to write to the log files on disk | 8M (or 15% of available memory)
 
 You can also set the following mount points by passing the `-v /host:/container` flag to Docker.
 
@@ -63,6 +71,22 @@ run [`mysql_install_db`](https://dev.mysql.com/doc/refman/en/mysql-install-db.ht
 and setup necessary database users and passwords. After the database is initialized,
 or if it was already present, `mysqld` is executed and will run as PID 1. You can
  stop the detached container by running `docker stop mysql_database`.
+
+
+MySQL auto-tuning
+-----------------
+
+When the MySQL image is run with the `--memory` parameter set and you didn't
+specify value for some parameters, their values will be automatically
+calculated based on the available memory.
+
+| Variable name                   | Configuration parameter   | Relative value
+| :-------------------------------| ------------------------- | --------------
+| `MYSQL_KEY_BUFFER_SIZE`         | `key_buffer_size`         | 10%
+| `MYSQL_READ_BUFFER_SIZE`        | `read_buffer_size`        | 5%
+| `MYSQL_INNODB_BUFFER_POOL_SIZE` | `innodb_buffer_pool_size` | 50%
+| `MYSQL_INNODB_LOG_FILE_SIZE`    | `innodb_log_file_size`    | 15%
+| `MYSQL_INNODB_LOG_BUFFER_SIZE`  | `innodb_log_buffer_size`  | 15%
 
 
 MySQL root user

--- a/5.6/root/usr/bin/cgroup-limits
+++ b/5.6/root/usr/bin/cgroup-limits
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+
+"""
+Script for parsing cgroup information
+
+This script will read some limits from the cgroup system and parse
+them, printing out "VARIABLE=VALUE" on each line for every limit that is
+successfully read. Output of this script can be directly fed into
+bash's export command. Recommended usage from a bash script:
+
+    set -o errexit
+    export_vars=$(cgroup-limits) ; export $export_vars
+
+Variables currently supported:
+    MAX_MEMORY_LIMIT_IN_BYTES
+        Maximum possible limit MEMORY_LIMIT_IN_BYTES can have. This is
+        currently constant value of 9223372036854775807.
+    MEMORY_LIMIT_IN_BYTES
+        Maximum amount of user memory in bytes. If this value is set
+        to the same value as MAX_MEMORY_LIMIT_IN_BYTES, it means that
+        there is no limit set. The value is taken from
+        /sys/fs/cgroup/memory/memory.limit_in_bytes
+    NUMBER_OF_CORES
+        Number of detected CPU cores that can be used. This value is
+        calculated from /sys/fs/cgroup/cpuset/cpuset.cpus
+    NO_MEMORY_LIMIT
+        Set to "true" if MEMORY_LIMIT_IN_BYTES is so high that the caller
+        can act as if no memory limit was set. Undefined otherwise.
+"""
+
+from __future__ import print_function
+import sys
+
+
+def _read_file(path):
+    try:
+        with open(path, 'r') as f:
+            return f.read().strip()
+    except IOError:
+        return None
+
+
+def get_memory_limit():
+    """
+    Read memory limit, in bytes.
+    """
+
+    limit = _read_file('/sys/fs/cgroup/memory/memory.limit_in_bytes')
+    if limit is None or not limit.isdigit():
+        print("Warning: Can't detect memory limit from cgroups",
+              file=sys.stderr)
+        return None
+    return int(limit)
+
+
+def get_number_of_cores():
+    """
+    Read number of CPU cores.
+    """
+
+    core_count = 0
+
+    line = _read_file('/sys/fs/cgroup/cpuset/cpuset.cpus')
+    if line is None:
+        print("Warning: Can't detect number of CPU cores from cgroups",
+              file=sys.stderr)
+        return None
+
+    for group in line.split(','):
+        core_ids = list(map(int, group.split('-')))
+        if len(core_ids) == 2:
+            core_count += core_ids[1] - core_ids[0] + 1
+        else:
+            core_count += 1
+
+    return core_count
+
+
+if __name__ == "__main__":
+    env_vars = {
+        "MAX_MEMORY_LIMIT_IN_BYTES": 9223372036854775807,
+        "MEMORY_LIMIT_IN_BYTES": get_memory_limit(),
+        "NUMBER_OF_CORES": get_number_of_cores()
+    }
+
+    env_vars = {k: v for k, v in env_vars.items() if v is not None}
+
+    if env_vars.get("MEMORY_LIMIT_IN_BYTES", 0) >= 92233720368547:
+        env_vars["NO_MEMORY_LIMIT"] = "true"
+
+    for key, value in env_vars.items():
+        print("{0}={1}".format(key, value))

--- a/5.6/root/usr/bin/run-mysqld
+++ b/5.6/root/usr/bin/run-mysqld
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
@@ -9,6 +10,7 @@ set -eu
 log_info 'Processing MySQL configuration files ...'
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
+envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
 
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
   initialize_database "$@"

--- a/5.6/root/usr/bin/run-mysqld-master
+++ b/5.6/root/usr/bin/run-mysqld-master
@@ -2,6 +2,7 @@
 #
 # This is an entrypoint that runs the MySQL server in the 'master' mode.
 #
+export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
@@ -18,6 +19,7 @@ envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.c
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-master.cnf.template > /etc/my.cnf.d/master.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-repl-gtid.cnf.template > /etc/my.cnf.d/repl-gtid.cnf
+envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
 
 if [ ! -d "$MYSQL_DATADIR/mysql" ]; then
   initialize_database "$@"

--- a/5.6/root/usr/bin/run-mysqld-slave
+++ b/5.6/root/usr/bin/run-mysqld-slave
@@ -2,6 +2,7 @@
 #
 # This is an entrypoint that runs the MySQL server in the 'slave' mode.
 #
+export_vars=$(cgroup-limits); export $export_vars
 source ${CONTAINER_SCRIPTS_PATH}/common.sh
 set -eu
 
@@ -23,6 +24,7 @@ envsubst < ${CONTAINER_SCRIPTS_PATH}/my-base.cnf.template > /etc/my.cnf.d/base.c
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-slave.cnf.template > /etc/my.cnf.d/slave.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-repl-gtid.cnf.template > /etc/my.cnf.d/repl-gtid.cnf
+envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
 
 # Initialize MySQL database and wait for the MySQL master to accept
 # connections.

--- a/5.6/root/usr/share/container-scripts/mysql/common.sh
+++ b/5.6/root/usr/share/container-scripts/mysql/common.sh
@@ -14,6 +14,28 @@ export MYSQL_MAX_CONNECTIONS=${MYSQL_MAX_CONNECTIONS:-151}
 export MYSQL_FT_MIN_WORD_LEN=${MYSQL_FT_MIN_WORD_LEN:-4}
 export MYSQL_FT_MAX_WORD_LEN=${MYSQL_FT_MAX_WORD_LEN:-20}
 export MYSQL_AIO=${MYSQL_AIO:-1}
+export MYSQL_MAX_ALLOWED_PACKET=${MYSQL_MAX_ALLOWED_PACKET:-200M}
+export MYSQL_TABLE_OPEN_CACHE=${MYSQL_TABLE_OPEN_CACHE:-400}
+export MYSQL_SORT_BUFFER_SIZE=${MYSQL_SORT_BUFFER_SIZE:-256K}
+
+if [ -n "${NO_MEMORY_LIMIT:-}" -o -z "${MEMORY_LIMIT_IN_BYTES:-}" ]; then
+  key_buffer_size='32M'
+  read_buffer_size='8M'
+  innodb_buffer_pool_size='32M'
+  innodb_log_file_size='8M'
+  innodb_log_buffer_size='8M'
+else
+  key_buffer_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.1))")M"
+  read_buffer_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.05))")M"
+  innodb_buffer_pool_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.5))")M"
+  innodb_log_file_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.15))")M"
+  innodb_log_buffer_size="$(python -c "print(int((${MEMORY_LIMIT_IN_BYTES}/(1024*1024))*0.15))")M"
+fi
+export MYSQL_KEY_BUFFER_SIZE=${MYSQL_KEY_BUFFER_SIZE:-$key_buffer_size}
+export MYSQL_READ_BUFFER_SIZE=${MYSQL_READ_BUFFER_SIZE:-$read_buffer_size}
+export MYSQL_INNODB_BUFFER_POOL_SIZE=${MYSQL_INNODB_BUFFER_POOL_SIZE:-$innodb_buffer_pool_size}
+export MYSQL_INNODB_LOG_FILE_SIZE=${MYSQL_INNODB_LOG_FILE_SIZE:-$innodb_log_file_size}
+export MYSQL_INNODB_LOG_BUFFER_SIZE=${MYSQL_INNODB_LOG_BUFFER_SIZE:-$innodb_log_buffer_size}
 
 # Be paranoid and stricter than we should be.
 # https://dev.mysql.com/doc/refman/en/identifiers.html

--- a/5.6/root/usr/share/container-scripts/mysql/my-paas.cnf.template
+++ b/5.6/root/usr/share/container-scripts/mysql/my-paas.cnf.template
@@ -9,12 +9,18 @@ lower_case_table_names = ${MYSQL_LOWER_CASE_TABLE_NAMES}
 # The maximum permitted number of simultaneous client connections. Default: 151
 max_connections = ${MYSQL_MAX_CONNECTIONS}
 
-# The minimum length of the word to be included in a FULLTEXT index. Default: 4
+# The minimum/maximum lengths of the word to be included in a FULLTEXT index. Default: 4/20
 ft_min_word_len = ${MYSQL_FT_MIN_WORD_LEN}
-
-# The maximum length of the word to be included in a FULLTEXT index. Default: 20
 ft_max_word_len = ${MYSQL_FT_MAX_WORD_LEN}
 
 # In case the native AIO is broken. Default: 1
 # See http://help.directadmin.com/item.php?id=529
 innodb_use_native_aio = ${MYSQL_AIO}
+
+[myisamchk]
+# The minimum/maximum lengths of the word to be included in a FULLTEXT index. Default: 4/20
+#
+# To ensure that myisamchk and the server use the same values for full-text
+# parameters, we placed them in both sections.
+ft_min_word_len = ${MYSQL_FT_MIN_WORD_LEN}
+ft_max_word_len = ${MYSQL_FT_MAX_WORD_LEN}

--- a/5.6/root/usr/share/container-scripts/mysql/my-tuning.cnf.template
+++ b/5.6/root/usr/share/container-scripts/mysql/my-tuning.cnf.template
@@ -1,0 +1,28 @@
+[mysqld]
+key_buffer_size = ${MYSQL_KEY_BUFFER_SIZE}
+max_allowed_packet = ${MYSQL_MAX_ALLOWED_PACKET}
+table_open_cache = ${MYSQL_TABLE_OPEN_CACHE}
+sort_buffer_size = ${MYSQL_SORT_BUFFER_SIZE}
+read_buffer_size = ${MYSQL_READ_BUFFER_SIZE}
+read_rnd_buffer_size = 256K
+net_buffer_length = 2K
+thread_stack = 256K
+myisam_sort_buffer_size = 2M
+
+# It is recommended that innodb_buffer_pool_size is configured to 50 to 75 percent of system memory.
+innodb_buffer_pool_size = ${MYSQL_INNODB_BUFFER_POOL_SIZE}
+innodb_additional_mem_pool_size = 2M
+# Set .._log_file_size to 25 % of buffer pool size
+innodb_log_file_size = ${MYSQL_INNODB_LOG_FILE_SIZE}
+innodb_log_buffer_size = ${MYSQL_INNODB_LOG_BUFFER_SIZE}
+
+[mysqldump]
+quick
+max_allowed_packet = 16M
+
+[mysql]
+no-auto-rehash
+
+[myisamchk]
+key_buffer_size = 8M
+sort_buffer_size = 8M

--- a/5.6/root/usr/share/container-scripts/mysql/validate-variables.sh
+++ b/5.6/root/usr/share/container-scripts/mysql/validate-variables.sh
@@ -13,6 +13,14 @@ function usage() {
   echo "  MYSQL_FT_MIN_WORD_LEN (default: 4)"
   echo "  MYSQL_FT_MAX_WORD_LEN (default: 20)"
   echo "  MYSQL_AIO (default: 1)"
+  echo "  MYSQL_KEY_BUFFER_SIZE (default: 32M or 10% of available memory)"
+  echo "  MYSQL_MAX_ALLOWED_PACKET (default: 200M)"
+  echo "  MYSQL_TABLE_OPEN_CACHE (default: 400)"
+  echo "  MYSQL_SORT_BUFFER_SIZE (default: 256K)"
+  echo "  MYSQL_READ_BUFFER_SIZE (default: 8M or 5% of available memory)"
+  echo "  MYSQL_INNODB_BUFFER_POOL_SIZE (default: 32M or 50% of available memory)"
+  echo "  MYSQL_INNODB_LOG_FILE_SIZE (default: 8M or 15% of available memory)"
+  echo "  MYSQL_INNODB_LOG_BUFFER_SIZE (default: 8M or 15% of available memory)"
   exit 1
 }
 

--- a/5.6/test/run
+++ b/5.6/test/run
@@ -128,15 +128,15 @@ function run_replication_test() {
   # Run the MySQL master
   docker run $cluster_args -e MYSQL_USER=user -e MYSQL_PASSWORD=foo \
     -e MYSQL_ROOT_PASSWORD=root \
-    -d --cidfile ${CIDFILE_DIR}/master.cid $IMAGE_NAME mysqld-master \
-    --innodb_buffer_pool_size=5242880
+    -e MYSQL_INNODB_BUFFER_POOL_SIZE=5M \
+    -d --cidfile ${CIDFILE_DIR}/master.cid $IMAGE_NAME mysqld-master
   local master_ip
   master_ip=$(get_container_ip master.cid)
 
   # Run the MySQL slave
   docker run $cluster_args -e MYSQL_MASTER_SERVICE_NAME=${master_ip} \
-    -d --cidfile ${CIDFILE_DIR}/slave.cid $IMAGE_NAME mysqld-slave \
-    --innodb_buffer_pool_size=5242880
+    -e MYSQL_INNODB_BUFFER_POOL_SIZE=5M \
+    -d --cidfile ${CIDFILE_DIR}/slave.cid $IMAGE_NAME mysqld-slave
   local slave_ip
   slave_ip=$(get_container_ip slave.cid)
 
@@ -225,12 +225,13 @@ function run_container_creation_tests() {
 }
 
 function test_config_option() {
-  local configuration="$1"
-  local option_name="$2"
-  local option_value="$3"
+  local container_name="$1"
+  local configuration="$2"
+  local option_name="$3"
+  local option_value="$4"
 
   if ! echo "$configuration" | grep -qx "$option_name[[:space:]]*=[[:space:]]*$option_value"; then
-    local configs="$(docker exec -t config_test bash -c 'set +f; shopt -s nullglob; echo /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/* | paste -s')"
+    local configs="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; echo /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/* | paste -s')"
     echo >&2 "FAIL: option '$option_name' should have value '$option_value', but it wasn't found in any of the configuration files ($configs):"
     echo >&2
     echo >&2 "$configuration"
@@ -244,9 +245,11 @@ function test_config_option() {
 function run_configuration_tests() {
   echo "  Testing image configuration settings"
 
+  local container_name=config_test
+
   create_container \
-    config_test \
-    --name config_test \
+    "$container_name" \
+    --name "$container_name" \
     --env MYSQL_USER=config_test_user \
     --env MYSQL_PASSWORD=config_test \
     --env MYSQL_DATABASE=db \
@@ -254,22 +257,63 @@ function run_configuration_tests() {
     --env MYSQL_MAX_CONNECTIONS=1337 \
     --env MYSQL_FT_MIN_WORD_LEN=8 \
     --env MYSQL_FT_MAX_WORD_LEN=15 \
+    --env MYSQL_MAX_ALLOWED_PACKET=10M \
+    --env MYSQL_TABLE_OPEN_CACHE=100 \
+    --env MYSQL_SORT_BUFFER_SIZE=256K \
+    --env MYSQL_KEY_BUFFER_SIZE=16M \
+    --env MYSQL_READ_BUFFER_SIZE=16M \
+    --env MYSQL_INNODB_BUFFER_POOL_SIZE=16M \
+    --env MYSQL_INNODB_LOG_FILE_SIZE=4M \
+    --env MYSQL_INNODB_LOG_BUFFER_SIZE=4M \
+    --env WORKAROUND_DOCKER_BUG_14203=
     #
 
-  test_connection config_test config_test_user config_test
+  test_connection "$container_name" config_test_user config_test
 
   # TODO: this check is far from perfect and could be improved:
   # - we should look for an option in the desired config, not in all of them
   # - we should respect section of the config (now we have duplicated options from a different sections)
   local configuration
-  configuration="$(docker exec -t config_test bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
+  configuration="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
 
-  test_config_option "$configuration" lower_case_table_names 1
-  test_config_option "$configuration" max_connections 1337
-  test_config_option "$configuration" ft_min_word_len 8
-  test_config_option "$configuration" ft_max_word_len 15
+  test_config_option "$container_name" "$configuration" lower_case_table_names 1
+  test_config_option "$container_name" "$configuration" max_connections 1337
+  test_config_option "$container_name" "$configuration" ft_min_word_len 8
+  test_config_option "$container_name" "$configuration" ft_max_word_len 15
+  test_config_option "$container_name" "$configuration" max_allowed_packet 10M
+  test_config_option "$container_name" "$configuration" table_open_cache 100
+  test_config_option "$container_name" "$configuration" sort_buffer_size 256K
+  test_config_option "$container_name" "$configuration" key_buffer_size 16M
+  test_config_option "$container_name" "$configuration" read_buffer_size 16M
+  test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 16M
+  test_config_option "$container_name" "$configuration" innodb_log_file_size 4M
+  test_config_option "$container_name" "$configuration" innodb_log_buffer_size 4M
 
-  docker stop config_test >/dev/null
+  docker stop "$container_name" >/dev/null
+
+  echo "  Success!"
+  echo "  Testing image auto-calculated configuration settings"
+
+  container_name=dynamic_config_test
+
+  DOCKER_ARGS='--memory=256m' create_container \
+    "$container_name" \
+    --name "$container_name" \
+    --env MYSQL_USER=config_test_user \
+    --env MYSQL_PASSWORD=config_test \
+    --env MYSQL_DATABASE=db
+
+  test_connection "$container_name" config_test_user config_test
+
+  configuration="$(docker exec -t "$container_name" bash -c 'set +f; shopt -s nullglob; egrep -hv "^(#|\!|\[|$)" /etc/my.cnf /etc/my.cnf.d/* /opt/rh/mysql*/root/etc/my.cnf /opt/rh/mysql*/root/etc/my.cnf.d/*' | sed 's,\(^[[:space:]]\+\|[[:space:]]\+$\),,' | sort -u)"
+
+  test_config_option "$container_name" "$configuration" key_buffer_size 25M
+  test_config_option "$container_name" "$configuration" read_buffer_size 12M
+  test_config_option "$container_name" "$configuration" innodb_buffer_pool_size 128M
+  test_config_option "$container_name" "$configuration" innodb_log_file_size 38M
+  test_config_option "$container_name" "$configuration" innodb_log_buffer_size 38M
+
+  docker stop "$container_name" >/dev/null
 
   echo "  Success!"
 }


### PR DESCRIPTION
This PR ports MySQL configuration and tuning from [V2 cartridge](https://github.com/openshift/origin-server/blob/73197c277b9ce9044be67a4e23b9951d120bc663/cartridges/openshift-origin-cartridge-mysql/conf/my.cnf.erb).

It also adds new parameters that can be configured:
- `MYSQL_MAX_ALLOWED_PACKET`
- `MYSQL_TABLE_OPEN_CACHE`
- `MYSQL_SORT_BUFFER_SIZE`
- `MYSQL_KEY_BUFFER_SIZE`
- `MYSQL_READ_BUFFER_SIZE`
- `MYSQL_INNODB_BUFFER_POOL_SIZE`
- `MYSQL_INNODB_LOG_FILE_SIZE`
- `MYSQL_INNODB_LOG_BUFFER_SIZE`

When container has limited amount of memory a couple of parameters (`MYSQL_KEY_BUFFER_SIZE` and `MYSQL_INNODB_*`) calculated dynamically.

I changed a few default values:
- `table_open_cache` (4 -> 400, because 4 is too small value and I decided to use default value from MySQL itself)
- `innodb_log_file_size` (16M -> 8M, because there is a comment that suggest to set it to 25 % of buffer pool size that has default value 32M)
-  `innodb_log_buffer_size` (16M -> 8M, because there is a comment that suggests to set it to 25 % of buffer pool size that has default value 32M)

Questions for discuss:
- I didn't port parameters for `default-storage-engine` and `default-time-zone` because they require special bash-coding. Sshould I port them too?
- All configuration in `/etc/my.cnf.d/tuning.cnf` -- is it normal file name? Maybe it's better to rename it or even merge with already existing configs?

PTAL @bparees @rhcarvalho @mnagy @mfojtik 

Related issues:
- https://trello.com/c/JH769zUA/893-3-update-mysql-image-to-autoconfigure-based-on-available-memory-evg
- https://trello.com/c/p3y4Glt4/902-add-max-allowed-packet-as-an-environment-variable-to-the-mysql-images
- https://bugzilla.redhat.com/show_bug.cgi?id=1326523

Need to be done:
- [x] write tests
- [x] `README.md`: document auto-tuning
- [ ] update openshift-docs
- [ ] apply changes to 5.6 (after getting feedback here)
- [ ] ensure that MySQL replication works
