### PR TITLE
Rename field portalIP -> clusterIP

### DIFF
--- a/5.5/examples/replica/README.md
+++ b/5.5/examples/replica/README.md
@@ -34,7 +34,7 @@ To learn more about how to create PersistentVolume, refer to [OpenShift document
 This resource provides 'headless' Service for the MySQL server(s) which acts
 as the 'master'. The headless means that the Service does not use IP
 addresses but it uses the DNS sub-system. This behavior is configured by setting
-the `portalIP` attribute to `None`.
+the `clusterIP` attribute to `None`.
 
 In this case, you can query the DNS (eg. `dig mysql-master A +search +short`) to
 obtain the list of the Service endpoints (the MySQL servers that subscribe to

--- a/5.5/examples/replica/mysql_replica.json
+++ b/5.5/examples/replica/mysql_replica.json
@@ -89,7 +89,7 @@
         "selector": {
           "name": "mysql-master"
         },
-        "portalIP": "None",
+        "clusterIP": "None",
         "type": "ClusterIP",
         "sessionAffinity": "None"
       },
@@ -118,7 +118,7 @@
         "selector": {
           "name": "mysql-slave"
         },
-        "portalIP": "None",
+        "clusterIP": "None",
         "type": "ClusterIP",
         "sessionAffinity": "None"
       },

--- a/5.6/examples/replica/README.md
+++ b/5.6/examples/replica/README.md
@@ -34,7 +34,7 @@ To learn more about how to create PersistentVolume, refer to [OpenShift document
 This resource provides 'headless' Service for the MySQL server(s) which acts
 as the 'master'. The headless means that the Service does not use IP
 addresses but it uses the DNS sub-system. This behavior is configured by setting
-the `portalIP` attribute to `None`.
+the `clusterIP` attribute to `None`.
 
 In this case, you can query the DNS (eg. `dig mysql-master A +search +short`) to
 obtain the list of the Service endpoints (the MySQL servers that subscribe to

--- a/5.6/examples/replica/mysql_replica.json
+++ b/5.6/examples/replica/mysql_replica.json
@@ -89,7 +89,7 @@
         "selector": {
           "name": "mysql-master"
         },
-        "portalIP": "None",
+        "clusterIP": "None",
         "type": "ClusterIP",
         "sessionAffinity": "None"
       },
@@ -118,7 +118,7 @@
         "selector": {
           "name": "mysql-slave"
         },
-        "portalIP": "None",
+        "clusterIP": "None",
         "type": "ClusterIP",
         "sessionAffinity": "None"
       },


### PR DESCRIPTION
portalIP was deprecated in favor of clusterIP.

@mnagy @bparees PTAL