### PR TITLE
Remove useless fields from template

### DIFF
--- a/5.5/examples/replica/mysql_replica.json
+++ b/5.5/examples/replica/mysql_replica.json
@@ -3,7 +3,6 @@
   "apiVersion": "v1",
   "metadata": {
     "name": "mysql-replication-example",
-    "creationTimestamp": null,
     "annotations": {
       "description": "MySQL Replication Example",
       "iconClass": "icon-database",
@@ -80,21 +79,13 @@
       "spec": {
         "ports": [
           {
-            "protocol": "TCP",
-            "port": 3306,
-            "targetPort": 3306,
-            "nodePort": 0
+            "port": 3306
           }
         ],
         "selector": {
           "name": "mysql-master"
         },
-        "clusterIP": "None",
-        "type": "ClusterIP",
-        "sessionAffinity": "None"
-      },
-      "status": {
-        "loadBalancer": {}
+        "clusterIP": "None"
       }
     },
     {
@@ -109,34 +100,24 @@
       "spec": {
         "ports": [
           {
-            "protocol": "TCP",
-            "port": 3306,
-            "targetPort": 3306,
-            "nodePort": 0
+            "port": 3306
           }
         ],
         "selector": {
           "name": "mysql-slave"
         },
-        "clusterIP": "None",
-        "type": "ClusterIP",
-        "sessionAffinity": "None"
-      },
-      "status": {
-        "loadBalancer": {}
+        "clusterIP": "None"
       }
     },
     {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mysql-master",
-        "creationTimestamp": null
+        "name": "mysql-master"
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -149,7 +130,6 @@
         },
         "template": {
           "metadata": {
-            "creationTimestamp": null,
             "labels": {
               "name": "mysql-master"
             }
@@ -172,8 +152,7 @@
                 ],
                 "ports": [
                   {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
+                    "containerPort": 3306
                   }
                 ],
                 "env": [
@@ -208,33 +187,22 @@
                     "mountPath": "/var/lib/mysql/data"
                   }
                 ],
-                "resources": {},
-                "terminationMessagePath": "/dev/termination-log",
-                "imagePullPolicy": "IfNotPresent",
-                "securityContext": {
-                  "capabilities": {},
-                  "privileged": false
-                }
+                "imagePullPolicy": "IfNotPresent"
               }
-            ],
-            "restartPolicy": "Always",
-            "dnsPolicy": "ClusterFirst"
+            ]
           }
         }
-      },
-      "status": {}
+      }
     },
     {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mysql-slave",
-        "creationTimestamp": null
+        "name": "mysql-slave"
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -247,7 +215,6 @@
         },
         "template": {
           "metadata": {
-            "creationTimestamp": null,
             "labels": {
               "name": "mysql-slave"
             }
@@ -262,8 +229,7 @@
                 ],
                 "ports": [
                   {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
+                    "containerPort": 3306
                   }
                 ],
                 "env": [
@@ -284,21 +250,12 @@
                     "value": "${MYSQL_DATABASE}"
                   }
                 ],
-                "resources": {},
-                "terminationMessagePath": "/dev/termination-log",
-                "imagePullPolicy": "IfNotPresent",
-                "securityContext": {
-                  "capabilities": {},
-                  "privileged": false
-                }
+                "imagePullPolicy": "IfNotPresent"
               }
-            ],
-            "restartPolicy": "Always",
-            "dnsPolicy": "ClusterFirst"
+            ]
           }
         }
-      },
-      "status": {}
+      }
     }
   ]
 }

--- a/5.6/examples/replica/mysql_replica.json
+++ b/5.6/examples/replica/mysql_replica.json
@@ -3,7 +3,6 @@
   "apiVersion": "v1",
   "metadata": {
     "name": "mysql-replication-example",
-    "creationTimestamp": null,
     "annotations": {
       "description": "MySQL Replication Example",
       "iconClass": "icon-database",
@@ -80,21 +79,13 @@
       "spec": {
         "ports": [
           {
-            "protocol": "TCP",
-            "port": 3306,
-            "targetPort": 3306,
-            "nodePort": 0
+            "port": 3306
           }
         ],
         "selector": {
           "name": "mysql-master"
         },
-        "clusterIP": "None",
-        "type": "ClusterIP",
-        "sessionAffinity": "None"
-      },
-      "status": {
-        "loadBalancer": {}
+        "clusterIP": "None"
       }
     },
     {
@@ -109,34 +100,24 @@
       "spec": {
         "ports": [
           {
-            "protocol": "TCP",
-            "port": 3306,
-            "targetPort": 3306,
-            "nodePort": 0
+            "port": 3306
           }
         ],
         "selector": {
           "name": "mysql-slave"
         },
-        "clusterIP": "None",
-        "type": "ClusterIP",
-        "sessionAffinity": "None"
-      },
-      "status": {
-        "loadBalancer": {}
+        "clusterIP": "None"
       }
     },
     {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mysql-master",
-        "creationTimestamp": null
+        "name": "mysql-master"
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -149,7 +130,6 @@
         },
         "template": {
           "metadata": {
-            "creationTimestamp": null,
             "labels": {
               "name": "mysql-master"
             }
@@ -172,8 +152,7 @@
                 ],
                 "ports": [
                   {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
+                    "containerPort": 3306
                   }
                 ],
                 "env": [
@@ -208,33 +187,22 @@
                     "mountPath": "/var/lib/mysql/data"
                   }
                 ],
-                "resources": {},
-                "terminationMessagePath": "/dev/termination-log",
-                "imagePullPolicy": "IfNotPresent",
-                "securityContext": {
-                  "capabilities": {},
-                  "privileged": false
-                }
+                "imagePullPolicy": "IfNotPresent"
               }
-            ],
-            "restartPolicy": "Always",
-            "dnsPolicy": "ClusterFirst"
+            ]
           }
         }
-      },
-      "status": {}
+      }
     },
     {
       "kind": "DeploymentConfig",
       "apiVersion": "v1",
       "metadata": {
-        "name": "mysql-slave",
-        "creationTimestamp": null
+        "name": "mysql-slave"
       },
       "spec": {
         "strategy": {
-          "type": "Recreate",
-          "resources": {}
+          "type": "Recreate"
         },
         "triggers": [
           {
@@ -247,7 +215,6 @@
         },
         "template": {
           "metadata": {
-            "creationTimestamp": null,
             "labels": {
               "name": "mysql-slave"
             }
@@ -262,8 +229,7 @@
                 ],
                 "ports": [
                   {
-                    "containerPort": 3306,
-                    "protocol": "TCP"
+                    "containerPort": 3306
                   }
                 ],
                 "env": [
@@ -284,21 +250,12 @@
                     "value": "${MYSQL_DATABASE}"
                   }
                 ],
-                "resources": {},
-                "terminationMessagePath": "/dev/termination-log",
-                "imagePullPolicy": "IfNotPresent",
-                "securityContext": {
-                  "capabilities": {},
-                  "privileged": false
-                }
+                "imagePullPolicy": "IfNotPresent"
               }
-            ],
-            "restartPolicy": "Always",
-            "dnsPolicy": "ClusterFirst"
+            ]
           }
         }
-      },
-      "status": {}
+      }
     }
   ]
 }


### PR DESCRIPTION
The template is complex enough with the information it needs to have.
Removing fields that were added automatically when bumping version with
an automated tool makes it a bit saner to maintain.

The fields being removed are all specifying default values.