### PR TITLE
Add persistent volume claim to slave

### DIFF
--- a/5.5/examples/replica/README.md
+++ b/5.5/examples/replica/README.md
@@ -25,9 +25,13 @@ This template will start with one MySQL master server and one slave server.
 
 ## Persistent storage
 
-In order to provide the persistent storage for the MySQL master server, the administrator
-of OpenShift needs to create a PersistentVolume that you can claim. This example requires a PersistentVolume of size 512m be available.
-To learn more about how to create PersistentVolume, refer to [OpenShift documentation](https://docs.openshift.org/latest/install_config/persistent_storage/persistent_storage_nfs.html)
+In order to provide persistent storage for MySQL, this example requires two
+persistent volumes of at least 512 MiB each.
+
+The OpenShift cluster administrator needs to create persistent volumes to be
+claimed when the template is instantiated. Refer to the [OpenShift
+documentation](https://docs.openshift.org/latest/install_config/persistent_storage/persistent_storage_nfs.html)
+to learn how to create persistent volumes.
 
 ### Service 'mysql-master'
 

--- a/5.5/examples/replica/mysql_replica.json
+++ b/5.5/examples/replica/mysql_replica.json
@@ -47,6 +47,13 @@
       "description": "The password for the root user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{12}"
+    },
+    {
+      "name": "VOLUME_CAPACITY",
+      "displayName": "Volume Capacity",
+      "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
+      "value": "1Gi",
+      "required": true
     }
   ],
   "objects": [
@@ -62,7 +69,24 @@
         ],
         "resources": {
           "requests": {
-            "storage": "512Mi"
+            "storage": "${VOLUME_CAPACITY}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql-slave"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "${VOLUME_CAPACITY}"
           }
         }
       }
@@ -220,6 +244,14 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "mysql-slave-data",
+                "persistentVolumeClaim": {
+                  "claimName": "mysql-slave"
+                }
+              }
+            ],
             "containers": [
               {
                 "name": "server",
@@ -248,6 +280,12 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${MYSQL_DATABASE}"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "mysql-slave-data",
+                    "mountPath": "/var/lib/mysql/data"
                   }
                 ],
                 "imagePullPolicy": "IfNotPresent"

--- a/5.5/root/usr/bin/run-mysqld-slave
+++ b/5.5/root/usr/bin/run-mysqld-slave
@@ -10,12 +10,6 @@ export_setting_variables
 
 log_volume_info $MYSQL_DATADIR
 
-# Just run normal server if the data directory is already initialized
-if [ -d "${MYSQL_DATADIR}/mysql" ]; then
-  log_info "Datadir already exists, execing ordinary run script"
-  exec /usr/bin/run-mysqld "$@"
-fi
-
 export MYSQL_RUNNING_AS_SLAVE=1
 
 [ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
@@ -31,31 +25,34 @@ envsubst < ${CONTAINER_SCRIPTS_PATH}/my-paas.cnf.template > /etc/my.cnf.d/paas.c
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-slave.cnf.template > /etc/my.cnf.d/slave.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
 
-# Initialize MySQL database and wait for the MySQL master to accept
-# connections.
-initialize_database "$@"
-wait_for_mysql_master
+if [ ! -e "${MYSQL_DATADIR}/mysql" ]; then
+  # Initialize MySQL database and wait for the MySQL master to accept
+  # connections.
+  initialize_database "$@"
+  wait_for_mysql_master
 
-# Get binlog file and position from master
-STATUS_INFO=$(mysql --host "$MYSQL_MASTER_SERVICE_NAME" "-u${MYSQL_MASTER_USER}" "-p${MYSQL_MASTER_PASSWORD}" replication -e 'SELECT File, Position from replication\G')
-BINLOG_POSITION=$(echo "$STATUS_INFO" | grep 'Position:' | head -n 1 | sed -e 's/^\s*Position: //')
-BINLOG_FILE=$(echo "$STATUS_INFO" | grep 'File:' | head -n 1 | sed -e 's/^\s*File: //')
+  # Get binlog file and position from master
+  STATUS_INFO=$(mysql --host "$MYSQL_MASTER_SERVICE_NAME" "-u${MYSQL_MASTER_USER}" "-p${MYSQL_MASTER_PASSWORD}" replication -e 'SELECT File, Position from replication\G')
+  BINLOG_POSITION=$(echo "$STATUS_INFO" | grep 'Position:' | head -n 1 | sed -e 's/^\s*Position: //')
+  BINLOG_FILE=$(echo "$STATUS_INFO" | grep 'File:' | head -n 1 | sed -e 's/^\s*File: //')
 
-if [ -z "${BINLOG_FILE}" -o -z "${BINLOG_POSITION}" ] ; then
-  echo "Could not read binlog position or file from master"
-  exit 1
-fi
+  if [ -z "${BINLOG_FILE}" -o -z "${BINLOG_POSITION}" ] ; then
+    echo "Could not read binlog position or file from master"
+    exit 1
+  fi
 
-mysql $mysql_flags <<EOSQL
-  CHANGE MASTER TO MASTER_HOST='${MYSQL_MASTER_SERVICE_NAME}',MASTER_USER='${MYSQL_MASTER_USER}', MASTER_PASSWORD='${MYSQL_MASTER_PASSWORD}', MASTER_LOG_FILE='${BINLOG_FILE}', MASTER_LOG_POS=${BINLOG_POSITION};
-  SET GLOBAL SQL_SLAVE_SKIP_COUNTER = 1; SLAVE START;
+  mysql $mysql_flags <<EOSQL
+CHANGE MASTER TO MASTER_HOST='${MYSQL_MASTER_SERVICE_NAME}',MASTER_USER='${MYSQL_MASTER_USER}', MASTER_PASSWORD='${MYSQL_MASTER_PASSWORD}', MASTER_LOG_FILE='${BINLOG_FILE}', MASTER_LOG_POS=${BINLOG_POSITION};
+SET GLOBAL SQL_SLAVE_SKIP_COUNTER = 1; SLAVE START;
 EOSQL
 
-log_info 'Sourcing post-init.sh ...'
-[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+  log_info 'Sourcing post-init.sh ...'
+  [ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
 
-# Restart the MySQL server with public IP bindings
-shutdown_local_mysql
+  # Restart the MySQL server with public IP bindings
+  shutdown_local_mysql
+fi
+
 unset_env_vars
 log_volume_info $MYSQL_DATADIR
 log_info 'Running final exec -- Only MySQL server logs after this point'

--- a/5.6/examples/replica/README.md
+++ b/5.6/examples/replica/README.md
@@ -25,9 +25,13 @@ This template will start with one MySQL master server and one slave server.
 
 ## Persistent storage
 
-In order to provide the persistent storage for the MySQL master server, the administrator
-of OpenShift needs to create a PersistentVolume that you can claim. This example requires a PersistentVolume of size 512m be available.
-To learn more about how to create PersistentVolume, refer to [OpenShift documentation](https://docs.openshift.org/latest/install_config/persistent_storage/persistent_storage_nfs.html)
+In order to provide persistent storage for MySQL, this example requires two
+persistent volumes of at least 512 MiB each.
+
+The OpenShift cluster administrator needs to create persistent volumes to be
+claimed when the template is instantiated. Refer to the [OpenShift
+documentation](https://docs.openshift.org/latest/install_config/persistent_storage/persistent_storage_nfs.html)
+to learn how to create persistent volumes.
 
 ### Service 'mysql-master'
 

--- a/5.6/examples/replica/mysql_replica.json
+++ b/5.6/examples/replica/mysql_replica.json
@@ -47,6 +47,13 @@
       "description": "The password for the root user",
       "generate": "expression",
       "from": "[a-zA-Z0-9]{12}"
+    },
+    {
+      "name": "VOLUME_CAPACITY",
+      "displayName": "Volume Capacity",
+      "description": "Volume space available for data, e.g. 512Mi, 2Gi.",
+      "value": "1Gi",
+      "required": true
     }
   ],
   "objects": [
@@ -62,7 +69,24 @@
         ],
         "resources": {
           "requests": {
-            "storage": "512Mi"
+            "storage": "${VOLUME_CAPACITY}"
+          }
+        }
+      }
+    },
+    {
+      "kind": "PersistentVolumeClaim",
+      "apiVersion": "v1",
+      "metadata": {
+        "name": "mysql-slave"
+      },
+      "spec": {
+        "accessModes": [
+          "ReadWriteOnce"
+        ],
+        "resources": {
+          "requests": {
+            "storage": "${VOLUME_CAPACITY}"
           }
         }
       }
@@ -220,6 +244,14 @@
             }
           },
           "spec": {
+            "volumes": [
+              {
+                "name": "mysql-slave-data",
+                "persistentVolumeClaim": {
+                  "claimName": "mysql-slave"
+                }
+              }
+            ],
             "containers": [
               {
                 "name": "server",
@@ -248,6 +280,12 @@
                   {
                     "name": "MYSQL_DATABASE",
                     "value": "${MYSQL_DATABASE}"
+                  }
+                ],
+                "volumeMounts": [
+                  {
+                    "name": "mysql-slave-data",
+                    "mountPath": "/var/lib/mysql/data"
                   }
                 ],
                 "imagePullPolicy": "IfNotPresent"

--- a/5.6/root/usr/bin/run-mysqld-slave
+++ b/5.6/root/usr/bin/run-mysqld-slave
@@ -10,12 +10,6 @@ export_setting_variables
 
 log_volume_info $MYSQL_DATADIR
 
-# Just run normal server if the data directory is already initialized
-if [ -d "${MYSQL_DATADIR}/mysql" ]; then
-  log_info "Datadir already exists, execing ordinary run script"
-  exec /usr/bin/run-mysqld "$@"
-fi
-
 export MYSQL_RUNNING_AS_SLAVE=1
 
 [ -f ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh ] && source ${CONTAINER_SCRIPTS_PATH}/validate_replication_variables.sh
@@ -32,20 +26,23 @@ envsubst < ${CONTAINER_SCRIPTS_PATH}/my-slave.cnf.template > /etc/my.cnf.d/slave
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-repl-gtid.cnf.template > /etc/my.cnf.d/repl-gtid.cnf
 envsubst < ${CONTAINER_SCRIPTS_PATH}/my-tuning.cnf.template > /etc/my.cnf.d/tuning.cnf
 
-# Initialize MySQL database and wait for the MySQL master to accept
-# connections.
-initialize_database "$@"
-wait_for_mysql_master
+if [ ! -e "${MYSQL_DATADIR}/mysql" ]; then
+  # Initialize MySQL database and wait for the MySQL master to accept
+  # connections.
+  initialize_database "$@"
+  wait_for_mysql_master
 
-mysql $mysql_flags <<EOSQL
-  CHANGE MASTER TO MASTER_HOST='${MYSQL_MASTER_SERVICE_NAME}',MASTER_USER='${MYSQL_MASTER_USER}', MASTER_PASSWORD='${MYSQL_MASTER_PASSWORD}', MASTER_AUTO_POSITION = 1;
+  mysql $mysql_flags <<EOSQL
+CHANGE MASTER TO MASTER_HOST='${MYSQL_MASTER_SERVICE_NAME}',MASTER_USER='${MYSQL_MASTER_USER}', MASTER_PASSWORD='${MYSQL_MASTER_PASSWORD}', MASTER_AUTO_POSITION = 1;
 EOSQL
 
-log_info 'Sourcing post-init.sh ...'
-[ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
+  log_info 'Sourcing post-init.sh ...'
+  [ -f ${CONTAINER_SCRIPTS_PATH}/post-init.sh ] && source ${CONTAINER_SCRIPTS_PATH}/post-init.sh
 
-# Restart the MySQL server with public IP bindings
-shutdown_local_mysql
+  # Restart the MySQL server with public IP bindings
+  shutdown_local_mysql
+fi
+
 unset_env_vars
 log_volume_info $MYSQL_DATADIR
 log_info 'Running final exec -- Only MySQL server logs after this point'


### PR DESCRIPTION
This accommodates for slave restarts without needing to re-sync the entire database, as well as having a hot backup of the data.

Changes to run-mysqld-slave are needed for proper pod start up with a persistent volume.